### PR TITLE
Implement mmap-based archive reader

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -53,7 +53,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -64,7 +64,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -92,6 +92,7 @@ dependencies = [
  "clap",
  "crc32fast",
  "flate2",
+ "fs4",
  "memmap2",
  "nom",
  "tempfile",
@@ -261,7 +262,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -296,6 +297,16 @@ checksum = "bfe33edd8e85a12a67454e37f8c75e730830d83e313556ab9ebf9ee7fbeb3bfb"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+]
+
+[[package]]
+name = "fs4"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8640e34b88f7652208ce9e88b1a37a2ae95227d84abec377ccd3c5cfeb141ed4"
+dependencies = [
+ "rustix",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -491,7 +502,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -557,7 +568,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -690,7 +701,7 @@ dependencies = [
  "getrandom",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -861,7 +872,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -925,20 +936,36 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.60.2"
+version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
 name = "windows-sys"
-version = "0.61.2"
+version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
- "windows-link",
+ "windows-targets 0.53.5",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
 
 [[package]]
@@ -948,15 +975,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
 dependencies = [
  "windows-link",
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -966,9 +999,21 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -978,9 +1023,21 @@ checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
 
 [[package]]
 name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -990,15 +1047,33 @@ checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
 
 [[package]]
 name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ chrono = "0.4.42"
 clap = { version = "4", features = ["derive"], optional = true }
 crc32fast = "1.5.0"
 flate2 = "1.1.5"
+fs4 = "0.13.1"
 memmap2 = "0.9.9"
 nom = "8.0.0"
 tempfile = "3.24.0"

--- a/src/error.rs
+++ b/src/error.rs
@@ -36,4 +36,21 @@ pub enum BaleError {
     /// Path contains invalid UTF-8.
     #[error("invalid path: not valid UTF-8")]
     InvalidPath,
+
+    /// Archive is too small to contain a valid trailer.
+    #[error("archive too small: {size} bytes, minimum is {minimum}")]
+    TooSmall {
+        /// Actual size of the archive.
+        size: u64,
+        /// Minimum size required.
+        minimum: u64,
+    },
+
+    /// Entry not found in archive.
+    #[error("entry not found: {0}")]
+    EntryNotFound(String),
+
+    /// Archive data is corrupted or invalid.
+    #[error("corrupted archive: {0}")]
+    Corrupted(String),
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,10 @@ mod eocd;
 mod error;
 /// Local File Header for ZIP entries.
 mod local_file;
+/// Memory-mapped file access.
+mod mmap;
+/// Zero-copy archive reader.
+mod reader;
 
 pub use archive::Archive;
 pub use archive_path::ArchivePath;
@@ -28,3 +32,5 @@ pub use dos_time::DosDateTime;
 pub use eocd::Eocd;
 pub use error::BaleError;
 pub use local_file::LocalFileHeader;
+pub use mmap::MappedArchive;
+pub use reader::ArchiveReader;

--- a/src/mmap.rs
+++ b/src/mmap.rs
@@ -1,0 +1,99 @@
+//! Memory-mapped file access for bale archives.
+
+use crate::BaleError;
+use std::fs::File;
+use std::path::Path;
+
+/// A read-only memory-mapped archive file.
+///
+/// This struct provides zero-copy access to archive contents by memory-mapping
+/// the underlying file. A shared lock is held on the file for the lifetime of
+/// this struct, allowing multiple concurrent readers while preventing writers.
+pub struct MappedArchive {
+    /// The underlying file handle (kept open to maintain the lock).
+    #[allow(dead_code)]
+    file: File,
+    /// The memory-mapped region.
+    mmap: memmap2::Mmap,
+}
+
+impl MappedArchive {
+    /// Opens a file and memory-maps it for reading.
+    ///
+    /// Acquires a shared lock on the file, allowing multiple concurrent readers
+    /// while preventing exclusive writers.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    /// - The file cannot be opened
+    /// - The shared lock cannot be acquired
+    /// - Memory mapping fails
+    ///
+    /// # Safety
+    ///
+    /// Memory mapping is inherently unsafe because the underlying file could
+    /// be modified by another process while mapped. This implementation
+    /// mitigates this by holding a shared lock on the file, preventing
+    /// cooperative writers from modifying it during the mapping lifetime.
+    pub fn open(path: impl AsRef<Path>) -> Result<Self, BaleError> {
+        let file = File::open(path.as_ref())?;
+        file.lock_shared()?;
+        // SAFETY: We hold a shared lock on the file, preventing cooperative
+        // writers from modifying it while mapped.
+        #[allow(unsafe_code)]
+        let mmap = unsafe { memmap2::Mmap::map(&file)? };
+        Ok(Self { file, mmap })
+    }
+
+    /// Returns the length of the mapped region in bytes.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.mmap.len()
+    }
+
+    /// Returns true if the mapped region is empty.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.mmap.is_empty()
+    }
+
+    /// Returns a byte slice of the entire mapped region.
+    #[must_use]
+    pub fn as_bytes(&self) -> &[u8] {
+        &self.mmap
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use tempfile::NamedTempFile;
+
+    /// Opening a valid file returns a mapped archive.
+    #[test]
+    fn open_valid_file() {
+        let mut file = NamedTempFile::new().unwrap();
+        file.write_all(b"test data").unwrap();
+        let mapped = MappedArchive::open(file.path()).unwrap();
+        assert_eq!(mapped.len(), 9);
+        assert_eq!(mapped.as_bytes(), b"test data");
+    }
+
+    /// Opening a nonexistent file returns an error.
+    #[test]
+    fn open_nonexistent_file() {
+        let result = MappedArchive::open("/nonexistent/path/to/file.bale");
+        assert!(result.is_err());
+    }
+
+    /// Empty files can be mapped.
+    #[test]
+    fn open_empty_file() {
+        let file = NamedTempFile::new().unwrap();
+        let mapped = MappedArchive::open(file.path()).unwrap();
+        assert!(mapped.is_empty());
+        assert_eq!(mapped.len(), 0);
+    }
+}

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -1,0 +1,329 @@
+//! Zero-copy archive reader using memory-mapped I/O.
+
+use crate::{BaleEocd, BaleError, CentralDirectoryHeader, Eocd, LocalFileHeader, MappedArchive};
+use std::path::Path;
+use zerocopy::FromBytes;
+
+/// A zero-copy reader for bale archives.
+///
+/// This struct provides read access to archive contents through memory-mapped
+/// I/O, enabling zero-copy access to file data. The archive remains mapped
+/// for the lifetime of this struct.
+///
+/// # Example
+///
+/// ```ignore
+/// let reader = ArchiveReader::open("archive.bale")?;
+/// for (header, path) in reader.iter_entries() {
+///     let data = reader.read_data(header);
+///     // process data...
+/// }
+/// ```
+pub struct ArchiveReader {
+    /// The memory-mapped archive.
+    mmap: MappedArchive,
+    /// Parsed EOCD from the trailer.
+    eocd: Eocd,
+    /// Parsed BaleEocd from the trailer.
+    bale_eocd: BaleEocd,
+}
+
+impl ArchiveReader {
+    /// Opens an archive for reading.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    /// - The file cannot be opened or memory-mapped
+    /// - The archive is too small to contain a valid trailer
+    /// - The EOCD or BaleEocd signature is invalid
+    pub fn open(path: impl AsRef<Path>) -> Result<Self, BaleError> {
+        let mmap = MappedArchive::open(path)?;
+
+        // Parse and validate trailer, extracting owned copies.
+        let (eocd, bale_eocd) = Self::parse_trailer(&mmap)?;
+
+        Ok(Self {
+            mmap,
+            eocd,
+            bale_eocd,
+        })
+    }
+
+    /// Parses and validates the trailer, returning owned copies of EOCD and BaleEocd.
+    fn parse_trailer(mmap: &MappedArchive) -> Result<(Eocd, BaleEocd), BaleError> {
+        let bytes = mmap.as_bytes();
+
+        // Check minimum size.
+        if bytes.len() < BaleEocd::COMBINED_SIZE {
+            return Err(BaleError::TooSmall {
+                size: bytes.len() as u64,
+                minimum: BaleEocd::COMBINED_SIZE as u64,
+            });
+        }
+
+        // Parse trailer from the last 256 bytes.
+        let trailer_start = bytes.len() - BaleEocd::COMBINED_SIZE;
+        let trailer = &bytes[trailer_start..];
+
+        // Parse EOCD (first 22 bytes of trailer).
+        let eocd = Eocd::ref_from_bytes(&trailer[..Eocd::SIZE])
+            .map_err(|e| BaleError::Corrupted(format!("invalid EOCD: {e}")))?;
+
+        // Validate EOCD signature.
+        if eocd.signature.get() != Eocd::SIGNATURE {
+            return Err(BaleError::InvalidSignature {
+                expected: Eocd::SIGNATURE,
+                found: eocd.signature.get(),
+            });
+        }
+
+        // Parse BaleEocd (remaining 234 bytes).
+        let bale_eocd = BaleEocd::ref_from_bytes(&trailer[Eocd::SIZE..])
+            .map_err(|e| BaleError::Corrupted(format!("invalid BaleEocd: {e}")))?;
+
+        // Validate BaleEocd magic.
+        if !bale_eocd.is_valid() {
+            return Err(BaleError::InvalidSignature {
+                expected: BaleEocd::MAGIC,
+                found: bale_eocd.magic.get(),
+            });
+        }
+
+        Ok((*eocd, *bale_eocd))
+    }
+
+    /// Returns the number of entries in the archive.
+    #[must_use]
+    pub fn entry_count(&self) -> usize {
+        self.eocd.cd_entries_total.get() as usize
+    }
+
+    /// Returns the configured path size for this archive.
+    #[must_use]
+    pub fn path_size(&self) -> usize {
+        self.bale_eocd.path_size() as usize
+    }
+
+    /// Returns the configured alignment for this archive.
+    #[must_use]
+    pub fn alignment(&self) -> u32 {
+        self.bale_eocd.alignment()
+    }
+
+    /// Returns an iterator over all Central Directory entries.
+    ///
+    /// Each item is a tuple of (header, path_bytes) where path_bytes is the
+    /// null-padded path from the CD entry.
+    pub fn iter_entries(&self) -> impl Iterator<Item = (&CentralDirectoryHeader, &[u8])> {
+        let bytes = self.mmap.as_bytes();
+        let cd_offset = self.eocd.cd_offset.get() as usize;
+        let path_size = self.path_size();
+        let stride = CentralDirectoryHeader::stride(path_size);
+        let entry_count = self.entry_count();
+
+        (0..entry_count).filter_map(move |i| {
+            let entry_start = cd_offset + i * stride;
+            let entry_end = entry_start + stride;
+            if entry_end > bytes.len() {
+                return None;
+            }
+
+            let entry_bytes = &bytes[entry_start..entry_end];
+            let header = CentralDirectoryHeader::ref_from_bytes(
+                &entry_bytes[..CentralDirectoryHeader::SIZE],
+            )
+            .ok()?;
+            let path = &entry_bytes[CentralDirectoryHeader::SIZE..];
+
+            Some((header, path))
+        })
+    }
+
+    /// Finds an entry by path using linear scan.
+    ///
+    /// Returns the last matching entry (for shadowed duplicates).
+    /// The path comparison is byte-exact against the null-padded path.
+    #[must_use]
+    pub fn find_entry(&self, path: &str) -> Option<&CentralDirectoryHeader> {
+        let path_bytes = path.as_bytes();
+        let path_size = self.path_size();
+
+        // Path must fit within path_size.
+        if path_bytes.len() > path_size {
+            return None;
+        }
+
+        let mut result = None;
+
+        for (header, stored_path) in self.iter_entries() {
+            // Check if path matches (with null padding).
+            if stored_path.starts_with(path_bytes)
+                && stored_path[path_bytes.len()..].iter().all(|&b| b == 0)
+            {
+                result = Some(header);
+            }
+        }
+
+        result
+    }
+
+    /// Returns a zero-copy slice of the file data for the given entry.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the entry's offset or size is invalid.
+    pub fn read_data(&self, entry: &CentralDirectoryHeader) -> Result<&[u8], BaleError> {
+        let bytes = self.mmap.as_bytes();
+        let local_offset = entry.local_header_offset.get() as usize;
+        let path_size = self.path_size();
+        let data_size = entry.uncompressed_size.get() as usize;
+
+        // Calculate where the data starts (after LocalFileHeader + path).
+        let data_start = local_offset + LocalFileHeader::stride(path_size);
+        let data_end = data_start + data_size;
+
+        if data_end > bytes.len() {
+            return Err(BaleError::Corrupted(format!(
+                "entry data extends beyond archive: offset={local_offset}, size={data_size}"
+            )));
+        }
+
+        Ok(&bytes[data_start..data_end])
+    }
+
+    /// Returns a reference to the EOCD.
+    #[must_use]
+    pub fn eocd(&self) -> &Eocd {
+        &self.eocd
+    }
+
+    /// Returns a reference to the BaleEocd.
+    #[must_use]
+    pub fn bale_eocd(&self) -> &BaleEocd {
+        &self.bale_eocd
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Opening a file that is too small returns TooSmall error.
+    #[test]
+    fn too_small_file() {
+        use std::io::Write;
+        use tempfile::NamedTempFile;
+
+        let mut file = NamedTempFile::new().unwrap();
+        file.write_all(&[0u8; 100]).unwrap(); // Less than 256 bytes
+
+        let result = ArchiveReader::open(file.path());
+        assert!(matches!(result, Err(BaleError::TooSmall { .. })));
+    }
+
+    /// Opening a file with invalid EOCD signature returns error.
+    #[test]
+    fn invalid_eocd_signature() {
+        use std::io::Write;
+        use tempfile::NamedTempFile;
+
+        let mut file = NamedTempFile::new().unwrap();
+        file.write_all(&[0u8; 256]).unwrap(); // All zeros, invalid signature
+
+        let result = ArchiveReader::open(file.path());
+        assert!(matches!(result, Err(BaleError::InvalidSignature { .. })));
+    }
+
+    /// Opening a valid empty archive works.
+    #[test]
+    fn open_empty_archive() {
+        use crate::Archive;
+        use tempfile::TempDir;
+
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("test.bale");
+
+        // Create empty archive using the builder.
+        let archive = Archive::create(&path).unwrap();
+        archive.finish().unwrap();
+
+        // Open with reader.
+        let reader = ArchiveReader::open(&path).unwrap();
+        assert_eq!(reader.entry_count(), 0);
+        assert_eq!(reader.path_size(), 256);
+        assert_eq!(reader.alignment(), 4096);
+    }
+
+    /// Reading entries from an archive with files.
+    #[test]
+    fn read_entries() {
+        use crate::Archive;
+        use std::fs::File;
+        use std::io::Write;
+        use tempfile::TempDir;
+
+        let dir = TempDir::new().unwrap();
+        let archive_path = dir.path().join("test.bale");
+
+        // Create a source file.
+        let src_path = dir.path().join("hello.txt");
+        let mut src = File::create(&src_path).unwrap();
+        src.write_all(b"Hello, World!").unwrap();
+
+        // Create archive with one file.
+        let mut archive = Archive::create(&archive_path).unwrap();
+        archive.add_file(&src_path, "hello.txt").unwrap();
+        archive.finish().unwrap();
+
+        // Open with reader.
+        let reader = ArchiveReader::open(&archive_path).unwrap();
+        assert_eq!(reader.entry_count(), 1);
+
+        // Check entry.
+        let entries: Vec<_> = reader.iter_entries().collect();
+        assert_eq!(entries.len(), 1);
+        let (header, path) = entries[0];
+        assert!(path.starts_with(b"hello.txt"));
+        assert_eq!(header.uncompressed_size.get(), 13);
+
+        // Read data.
+        let data = reader.read_data(header).unwrap();
+        assert_eq!(data, b"Hello, World!");
+    }
+
+    /// find_entry returns the entry for an existing path.
+    #[test]
+    fn find_existing_entry() {
+        use crate::Archive;
+        use std::fs::File;
+        use std::io::Write;
+        use tempfile::TempDir;
+
+        let dir = TempDir::new().unwrap();
+        let archive_path = dir.path().join("test.bale");
+
+        // Create source files.
+        let src1 = dir.path().join("a.txt");
+        File::create(&src1).unwrap().write_all(b"aaa").unwrap();
+        let src2 = dir.path().join("b.txt");
+        File::create(&src2).unwrap().write_all(b"bbbbb").unwrap();
+
+        // Create archive.
+        let mut archive = Archive::create(&archive_path).unwrap();
+        archive.add_file(&src1, "a.txt").unwrap();
+        archive.add_file(&src2, "b.txt").unwrap();
+        archive.finish().unwrap();
+
+        // Open and find entries.
+        let reader = ArchiveReader::open(&archive_path).unwrap();
+        let entry_a = reader.find_entry("a.txt").unwrap();
+        assert_eq!(entry_a.uncompressed_size.get(), 3);
+
+        let entry_b = reader.find_entry("b.txt").unwrap();
+        assert_eq!(entry_b.uncompressed_size.get(), 5);
+
+        // Non-existent entry.
+        assert!(reader.find_entry("c.txt").is_none());
+    }
+}


### PR DESCRIPTION
## Summary

- Add `fs4` dependency for cross-platform shared file locking
- Add `MappedArchive` wrapper that acquires shared lock on open
- Add `ArchiveReader` with zero-copy access to archive contents
- Add error variants: `TooSmall`, `EntryNotFound`, `Corrupted`

## API

```rust
let reader = ArchiveReader::open("archive.bale")?;
for (header, path) in reader.iter_entries() {
    let data = reader.read_data(header)?;  // zero-copy slice
}
```

## New Files

- `src/mmap.rs` - shared-lock mmap wrapper
- `src/reader.rs` - zero-copy archive reader

Closes #6