### PR TITLE
Add compact operation, new CLI commands, and deprecate Archive

### DIFF
--- a/src/archive.rs
+++ b/src/archive.rs
@@ -26,6 +26,13 @@ struct EntryInfo {
 ///
 /// Use [`Archive::create`] to start building an archive, [`Archive::add_file`]
 /// to add files, and [`Archive::finish`] to finalize.
+///
+/// # Deprecated
+///
+/// This legacy builder uses non-mmap I/O. Use [`crate::ArchiveWriter`] instead,
+/// which provides mmap-based I/O with file locking, append support, and deletion.
+#[deprecated(since = "0.1.0", note = "Use ArchiveWriter instead")]
+#[allow(deprecated)]
 pub struct Archive {
     /// The underlying file.
     file: File,
@@ -39,6 +46,7 @@ pub struct Archive {
     path_size: u16,
 }
 
+#[allow(deprecated)]
 impl Archive {
     /// Default alignment for file data (4096 bytes).
     pub const DEFAULT_ALIGNMENT: u32 = 4096;
@@ -282,6 +290,7 @@ impl Archive {
 }
 
 #[cfg(test)]
+#[allow(deprecated)]
 mod tests {
     use super::*;
     use std::io::Write;

--- a/src/bin/bale/cli.rs
+++ b/src/bin/bale/cli.rs
@@ -43,4 +43,32 @@ pub enum Command {
         #[arg(required = true)]
         files: Vec<PathBuf>,
     },
+    /// List entries in a bale archive.
+    List {
+        /// The archive to list.
+        archive: PathBuf,
+    },
+    /// Extract entries from a bale archive.
+    Extract {
+        /// The archive to extract from.
+        archive: PathBuf,
+        /// Output directory (defaults to current directory).
+        #[arg(short, long, default_value = ".")]
+        output: PathBuf,
+        /// Entries to extract (if empty, extracts all).
+        entries: Vec<String>,
+    },
+    /// Delete entries from a bale archive.
+    Delete {
+        /// The archive to modify.
+        archive: PathBuf,
+        /// Entries to delete.
+        #[arg(required = true)]
+        entries: Vec<String>,
+    },
+    /// Compact a bale archive, removing orphaned data.
+    Compact {
+        /// The archive to compact.
+        archive: PathBuf,
+    },
 }

--- a/src/bin/bale/commands/add.rs
+++ b/src/bin/bale/commands/add.rs
@@ -2,7 +2,7 @@
 
 use std::path::{Path, PathBuf};
 
-use bale::Archive;
+use bale::{ArchivePath, ArchiveWriter};
 
 use crate::error::BaleCliError;
 
@@ -12,14 +12,15 @@ pub fn run(
     prefix: &str,
     files: &[PathBuf],
 ) -> Result<(), BaleCliError> {
-    let mut archive = Archive::create(archive_path)?;
+    let mut writer = ArchiveWriter::create(archive_path)?;
 
     for file in files {
         let name = file.file_name().unwrap_or(file.as_os_str());
         let dest = Path::new(prefix).join(name);
-        archive.add_file_path(file, &dest)?;
+        let archive_path = ArchivePath::try_from_path(&dest)?;
+        writer.add_file(file, archive_path.as_str())?;
     }
 
-    archive.finish()?;
+    writer.sync()?;
     Ok(())
 }

--- a/src/bin/bale/commands/compact.rs
+++ b/src/bin/bale/commands/compact.rs
@@ -1,0 +1,23 @@
+//! Compact command implementation.
+
+use std::path::Path;
+
+use bale::compact;
+
+use crate::error::BaleCliError;
+
+/// Compacts an archive, removing orphaned data.
+pub fn run(archive_path: impl AsRef<Path>) -> Result<(), BaleCliError> {
+    let stats = compact(archive_path)?;
+
+    #[allow(clippy::print_stdout)]
+    {
+        println!("Compacted archive:");
+        println!("  Original size:    {} bytes", stats.original_size);
+        println!("  Compacted size:   {} bytes", stats.compacted_size);
+        println!("  Entries removed:  {}", stats.entries_removed);
+        println!("  Bytes reclaimed:  {}", stats.bytes_reclaimed);
+    }
+
+    Ok(())
+}

--- a/src/bin/bale/commands/delete.rs
+++ b/src/bin/bale/commands/delete.rs
@@ -1,0 +1,37 @@
+//! Delete command implementation.
+
+use std::path::Path;
+
+use bale::ArchiveWriter;
+
+use crate::error::BaleCliError;
+
+/// Deletes entries from an archive.
+pub fn run(archive_path: impl AsRef<Path>, entries: &[String]) -> Result<(), BaleCliError> {
+    let mut writer = ArchiveWriter::open(archive_path)?;
+
+    let mut deleted_count = 0usize;
+    for entry_path in entries {
+        if writer.delete(entry_path) {
+            deleted_count += 1;
+            #[allow(clippy::print_stdout)]
+            {
+                println!("  deleted: {entry_path}");
+            }
+        } else {
+            #[allow(clippy::print_stdout)]
+            {
+                println!("  not found: {entry_path}");
+            }
+        }
+    }
+
+    writer.sync()?;
+
+    #[allow(clippy::print_stdout)]
+    {
+        println!("Deleted {deleted_count} entries");
+    }
+
+    Ok(())
+}

--- a/src/bin/bale/commands/extract.rs
+++ b/src/bin/bale/commands/extract.rs
@@ -1,0 +1,93 @@
+//! Extract command implementation.
+
+use std::fs::{self, File};
+use std::io::Write;
+use std::path::Path;
+
+use bale::ArchiveReader;
+
+use crate::error::BaleCliError;
+
+/// Extracts entries from an archive.
+///
+/// If no entries are specified, extracts all entries.
+pub fn run(
+    archive_path: impl AsRef<Path>,
+    output_dir: impl AsRef<Path>,
+    entries: &[String],
+) -> Result<(), BaleCliError> {
+    let reader = ArchiveReader::open(archive_path)?;
+    let output_dir = output_dir.as_ref();
+
+    // Create output directory if it doesn't exist.
+    fs::create_dir_all(output_dir)?;
+
+    if entries.is_empty() {
+        // Extract all entries.
+        for (header, path_bytes) in reader.iter_entries() {
+            extract_entry(&reader, header, path_bytes, output_dir)?;
+        }
+    } else {
+        // Extract specified entries.
+        for entry_path in entries {
+            if let Some(header) = reader.find_entry(entry_path) {
+                // Get path bytes from the header by re-iterating (find_entry only returns header).
+                for (h, path_bytes) in reader.iter_entries() {
+                    if std::ptr::eq(h, header) {
+                        extract_entry(&reader, header, path_bytes, output_dir)?;
+                        break;
+                    }
+                }
+            } else {
+                return Err(bale::BaleError::EntryNotFound(entry_path.clone()).into());
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Extracts a single entry to the output directory.
+fn extract_entry(
+    reader: &ArchiveReader,
+    header: &bale::CentralDirectoryHeader,
+    path_bytes: &[u8],
+    output_dir: &Path,
+) -> Result<(), BaleCliError> {
+    // Convert path bytes to string.
+    let path: String = path_bytes
+        .iter()
+        .copied()
+        .take_while(|&b| b != 0)
+        .map(|b| b as char)
+        .collect();
+
+    let dest_path = output_dir.join(&path);
+
+    // Create parent directories.
+    if let Some(parent) = dest_path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+
+    // Read and write data.
+    let data = reader.read_data(header)?;
+    let mut file = File::create(&dest_path)?;
+    file.write_all(data)?;
+
+    // Set permissions on Unix.
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mode = header.external_attrs.get() >> 16;
+        if mode != 0 {
+            fs::set_permissions(&dest_path, fs::Permissions::from_mode(mode))?;
+        }
+    }
+
+    #[allow(clippy::print_stdout)]
+    {
+        println!("  extracted: {path}");
+    }
+
+    Ok(())
+}

--- a/src/bin/bale/commands/list.rs
+++ b/src/bin/bale/commands/list.rs
@@ -1,0 +1,30 @@
+//! List command implementation.
+
+use std::path::Path;
+
+use bale::ArchiveReader;
+
+use crate::error::BaleCliError;
+
+/// Lists entries in an archive.
+pub fn run(archive_path: impl AsRef<Path>) -> Result<(), BaleCliError> {
+    let reader = ArchiveReader::open(archive_path)?;
+
+    #[allow(clippy::print_stdout)]
+    for (header, path_bytes) in reader.iter_entries() {
+        // Convert path bytes to string, trimming null padding.
+        let path: String = path_bytes
+            .iter()
+            .copied()
+            .take_while(|&b| b != 0)
+            .map(|b| b as char)
+            .collect();
+
+        let size = header.uncompressed_size.get();
+        let mode = header.external_attrs.get() >> 16;
+
+        println!("{mode:06o} {size:>10} {path}");
+    }
+
+    Ok(())
+}

--- a/src/bin/bale/commands/mod.rs
+++ b/src/bin/bale/commands/mod.rs
@@ -2,5 +2,13 @@
 
 /// Add files to an archive.
 pub mod add;
+/// Compact an archive.
+pub mod compact;
+/// Delete entries from an archive.
+pub mod delete;
+/// Extract entries from an archive.
+pub mod extract;
+/// List entries in an archive.
+pub mod list;
 /// Create or update file modification time.
 pub mod touch;

--- a/src/bin/bale/commands/touch.rs
+++ b/src/bin/bale/commands/touch.rs
@@ -4,7 +4,7 @@ use std::fs::{FileTimes, OpenOptions};
 use std::path::Path;
 use std::time::SystemTime;
 
-use bale::Archive;
+use bale::ArchiveWriter;
 
 use crate::error::BaleCliError;
 
@@ -21,7 +21,8 @@ pub fn run(path: impl AsRef<Path>) -> Result<(), BaleCliError> {
         let times = FileTimes::new().set_accessed(now).set_modified(now);
         file.set_times(times)?;
     } else {
-        Archive::create(path)?.finish()?;
+        let mut writer = ArchiveWriter::create(path)?;
+        writer.sync()?;
     }
 
     Ok(())

--- a/src/bin/bale/main.rs
+++ b/src/bin/bale/main.rs
@@ -34,5 +34,13 @@ fn run(cli: Cli) -> Result<(), BaleCliError> {
             prefix,
             files,
         } => commands::add::run(archive, &prefix, &files),
+        Command::List { archive } => commands::list::run(archive),
+        Command::Extract {
+            archive,
+            output,
+            entries,
+        } => commands::extract::run(archive, output, &entries),
+        Command::Delete { archive, entries } => commands::delete::run(archive, &entries),
+        Command::Compact { archive } => commands::compact::run(archive),
     }
 }

--- a/src/compact.rs
+++ b/src/compact.rs
@@ -1,0 +1,237 @@
+//! Archive compaction to reclaim space from orphaned data.
+
+use crate::{ArchiveReader, ArchiveWriter, BaleError};
+use std::collections::HashSet;
+use std::fs;
+use std::path::Path;
+
+/// Statistics from a compact operation.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct CompactStats {
+    /// Original archive size in bytes.
+    pub original_size: u64,
+    /// Compacted archive size in bytes.
+    pub compacted_size: u64,
+    /// Number of duplicate/shadowed entries removed.
+    pub entries_removed: usize,
+    /// Bytes reclaimed by compaction.
+    pub bytes_reclaimed: u64,
+}
+
+/// Compacts an archive, removing orphaned data and duplicate entries.
+///
+/// This operation:
+/// 1. Opens the archive for reading
+/// 2. Creates a temp file with a new writer
+/// 3. Copies non-duplicate entries (keeping only the last occurrence of each path)
+/// 4. Sorts entries by path for efficient binary search
+/// 5. Atomically replaces the original file
+///
+/// # Errors
+///
+/// Returns an error if:
+/// - The archive cannot be opened
+/// - The temp file cannot be created
+/// - Writing fails
+/// - The rename operation fails
+pub fn compact(path: impl AsRef<Path>) -> Result<CompactStats, BaleError> {
+    let path = path.as_ref();
+
+    // Get original size.
+    let original_size = fs::metadata(path)?.len();
+
+    // Open existing archive for reading.
+    let reader = ArchiveReader::open(path)?;
+    let alignment = reader.alignment();
+    let path_size = reader.path_size() as u16;
+
+    // Collect entries, keeping only the last occurrence of each path (shadowing).
+    // We iterate in order and track seen paths to identify duplicates.
+    let mut seen_paths: HashSet<Vec<u8>> = HashSet::new();
+    let mut entries_to_copy: Vec<_> = Vec::new();
+    let mut total_entries = 0usize;
+
+    for (header, path_bytes) in reader.iter_entries() {
+        total_entries += 1;
+        // Normalize path by trimming null padding for comparison.
+        let trimmed: Vec<u8> = path_bytes.iter().copied().take_while(|&b| b != 0).collect();
+
+        // Track all entries, we'll deduplicate later by keeping last occurrence.
+        entries_to_copy.push((header, path_bytes.to_vec(), trimmed.clone()));
+    }
+
+    // Deduplicate: reverse, keep first of each path, reverse back.
+    // This keeps the last occurrence of each path (shadowing behavior).
+    entries_to_copy.reverse();
+    let mut final_entries: Vec<_> = Vec::new();
+    for (header, path_bytes, trimmed) in entries_to_copy {
+        if seen_paths.insert(trimmed) {
+            final_entries.push((header, path_bytes));
+        }
+    }
+    final_entries.reverse();
+
+    // Sort by path for binary search.
+    final_entries.sort_by(|a, b| a.1.cmp(&b.1));
+
+    let entries_removed = total_entries - final_entries.len();
+
+    // Create temp file in same directory (for atomic rename).
+    let parent = path.parent().unwrap_or(Path::new("."));
+    let temp_path = parent.join(format!(
+        ".{}.compact.tmp",
+        path.file_name()
+            .and_then(|s| s.to_str())
+            .unwrap_or("archive")
+    ));
+
+    // Write compacted archive.
+    {
+        let mut writer = ArchiveWriter::create_with_options(&temp_path, alignment, path_size)?;
+
+        for (header, path_bytes) in &final_entries {
+            // Read the data from the original archive.
+            let data = reader.read_data(header)?;
+
+            // Get the path as a string (trimmed).
+            let path_str: String = path_bytes
+                .iter()
+                .copied()
+                .take_while(|&b| b != 0)
+                .map(|b| b as char)
+                .collect();
+
+            // Get mode from external attributes.
+            let mode = header.external_attrs.get() >> 16;
+
+            writer.add_entry(&path_str, data, mode)?;
+        }
+
+        writer.sync()?;
+    }
+
+    // Get compacted size.
+    let compacted_size = fs::metadata(&temp_path)?.len();
+
+    // Atomic rename.
+    fs::rename(&temp_path, path)?;
+
+    Ok(CompactStats {
+        original_size,
+        compacted_size,
+        entries_removed,
+        bytes_reclaimed: original_size.saturating_sub(compacted_size),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    /// Compacting an empty archive works.
+    #[test]
+    fn compact_empty_archive() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("test.bale");
+
+        // Create empty archive.
+        {
+            let mut writer = ArchiveWriter::create(&path).unwrap();
+            writer.sync().unwrap();
+        }
+
+        let stats = compact(&path).unwrap();
+        assert_eq!(stats.entries_removed, 0);
+
+        // Verify archive is still valid.
+        let reader = ArchiveReader::open(&path).unwrap();
+        assert_eq!(reader.entry_count(), 0);
+    }
+
+    /// Compacting removes shadowed duplicates.
+    #[test]
+    fn compact_removes_duplicates() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("test.bale");
+
+        // Create archive with duplicate entries.
+        {
+            let mut writer = ArchiveWriter::create(&path).unwrap();
+            writer.add_entry("file.txt", b"original", 0o644).unwrap();
+            writer.add_entry("file.txt", b"updated", 0o644).unwrap();
+            writer.add_entry("other.txt", b"other", 0o644).unwrap();
+            writer.sync().unwrap();
+        }
+
+        let original_size = fs::metadata(&path).unwrap().len();
+
+        let stats = compact(&path).unwrap();
+        assert_eq!(stats.entries_removed, 1); // One duplicate removed.
+        assert!(stats.compacted_size < original_size);
+
+        // Verify archive has 2 entries with correct data.
+        let reader = ArchiveReader::open(&path).unwrap();
+        assert_eq!(reader.entry_count(), 2);
+
+        let entry = reader.find_entry("file.txt").unwrap();
+        let data = reader.read_data(entry).unwrap();
+        assert_eq!(data, b"updated"); // Latest version kept.
+    }
+
+    /// Compacting sorts entries by path.
+    #[test]
+    fn compact_sorts_entries() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("test.bale");
+
+        // Create archive with unsorted entries.
+        {
+            let mut writer = ArchiveWriter::create(&path).unwrap();
+            writer.add_entry("c.txt", b"c", 0o644).unwrap();
+            writer.add_entry("a.txt", b"a", 0o644).unwrap();
+            writer.add_entry("b.txt", b"b", 0o644).unwrap();
+            writer.sync().unwrap();
+        }
+
+        compact(&path).unwrap();
+
+        // Verify entries are sorted.
+        let reader = ArchiveReader::open(&path).unwrap();
+        let paths: Vec<String> = reader
+            .iter_entries()
+            .map(|(_, p)| {
+                p.iter()
+                    .copied()
+                    .take_while(|&b| b != 0)
+                    .map(|b| b as char)
+                    .collect()
+            })
+            .collect();
+
+        assert_eq!(paths, vec!["a.txt", "b.txt", "c.txt"]);
+    }
+
+    /// Compacting preserves file permissions.
+    #[test]
+    fn compact_preserves_mode() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("test.bale");
+
+        {
+            let mut writer = ArchiveWriter::create(&path).unwrap();
+            writer.add_entry("exec.sh", b"#!/bin/bash", 0o755).unwrap();
+            writer.add_entry("data.txt", b"data", 0o644).unwrap();
+            writer.sync().unwrap();
+        }
+
+        compact(&path).unwrap();
+
+        let reader = ArchiveReader::open(&path).unwrap();
+        let exec_entry = reader.find_entry("exec.sh").unwrap();
+        let data_entry = reader.find_entry("data.txt").unwrap();
+
+        assert_eq!(exec_entry.external_attrs.get() >> 16, 0o755);
+        assert_eq!(data_entry.external_attrs.get() >> 16, 0o644);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,8 @@ mod archive_path;
 mod bale_eocd;
 /// Central Directory Header for ZIP entries.
 mod central_dir;
+/// Archive compaction.
+mod compact;
 /// MS-DOS date/time format for ZIP archives.
 mod dos_time;
 /// End of Central Directory record.
@@ -26,10 +28,12 @@ mod reader;
 /// Append-only archive writer.
 mod writer;
 
+#[allow(deprecated)]
 pub use archive::Archive;
 pub use archive_path::ArchivePath;
 pub use bale_eocd::BaleEocd;
 pub use central_dir::CentralDirectoryHeader;
+pub use compact::{CompactStats, compact};
 pub use dos_time::DosDateTime;
 pub use eocd::Eocd;
 pub use error::BaleError;

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -238,15 +238,17 @@ mod tests {
     /// Opening a valid empty archive works.
     #[test]
     fn open_empty_archive() {
-        use crate::Archive;
+        use crate::ArchiveWriter;
         use tempfile::TempDir;
 
         let dir = TempDir::new().unwrap();
         let path = dir.path().join("test.bale");
 
-        // Create empty archive using the builder.
-        let archive = Archive::create(&path).unwrap();
-        archive.finish().unwrap();
+        // Create empty archive using the writer (drop to release lock).
+        {
+            let mut writer = ArchiveWriter::create(&path).unwrap();
+            writer.sync().unwrap();
+        }
 
         // Open with reader.
         let reader = ArchiveReader::open(&path).unwrap();
@@ -258,23 +260,20 @@ mod tests {
     /// Reading entries from an archive with files.
     #[test]
     fn read_entries() {
-        use crate::Archive;
-        use std::fs::File;
-        use std::io::Write;
+        use crate::ArchiveWriter;
         use tempfile::TempDir;
 
         let dir = TempDir::new().unwrap();
         let archive_path = dir.path().join("test.bale");
 
-        // Create a source file.
-        let src_path = dir.path().join("hello.txt");
-        let mut src = File::create(&src_path).unwrap();
-        src.write_all(b"Hello, World!").unwrap();
-
-        // Create archive with one file.
-        let mut archive = Archive::create(&archive_path).unwrap();
-        archive.add_file(&src_path, "hello.txt").unwrap();
-        archive.finish().unwrap();
+        // Create archive with one file (drop to release lock).
+        {
+            let mut writer = ArchiveWriter::create(&archive_path).unwrap();
+            writer
+                .add_entry("hello.txt", b"Hello, World!", 0o644)
+                .unwrap();
+            writer.sync().unwrap();
+        }
 
         // Open with reader.
         let reader = ArchiveReader::open(&archive_path).unwrap();
@@ -295,25 +294,19 @@ mod tests {
     /// find_entry returns the entry for an existing path.
     #[test]
     fn find_existing_entry() {
-        use crate::Archive;
-        use std::fs::File;
-        use std::io::Write;
+        use crate::ArchiveWriter;
         use tempfile::TempDir;
 
         let dir = TempDir::new().unwrap();
         let archive_path = dir.path().join("test.bale");
 
-        // Create source files.
-        let src1 = dir.path().join("a.txt");
-        File::create(&src1).unwrap().write_all(b"aaa").unwrap();
-        let src2 = dir.path().join("b.txt");
-        File::create(&src2).unwrap().write_all(b"bbbbb").unwrap();
-
-        // Create archive.
-        let mut archive = Archive::create(&archive_path).unwrap();
-        archive.add_file(&src1, "a.txt").unwrap();
-        archive.add_file(&src2, "b.txt").unwrap();
-        archive.finish().unwrap();
+        // Create archive (drop to release lock).
+        {
+            let mut writer = ArchiveWriter::create(&archive_path).unwrap();
+            writer.add_entry("a.txt", b"aaa", 0o644).unwrap();
+            writer.add_entry("b.txt", b"bbbbb", 0o644).unwrap();
+            writer.sync().unwrap();
+        }
 
         // Open and find entries.
         let reader = ArchiveReader::open(&archive_path).unwrap();

--- a/tests/fixtures.rs
+++ b/tests/fixtures.rs
@@ -2,6 +2,8 @@
 //!
 //! Run with `cargo test --test fixtures -- --ignored` to regenerate fixtures.
 
+#![allow(deprecated)]
+
 use std::fs::File;
 use std::io::Write;
 use std::path::Path;


### PR DESCRIPTION
## Summary
- Add `src/compact.rs` with `compact()` function and `CompactStats`
  - Removes duplicate entries (keeps last occurrence)
  - Sorts entries by path for binary search
  - Atomic rename for safe replacement

- Add new CLI commands:
  - `list`: Show archive entries with mode and size
  - `extract`: Extract entries to output directory
  - `delete`: Remove entries from archive CD
  - `compact`: Compact archive to reclaim space

- Deprecate legacy `Archive` builder in favor of `ArchiveWriter`
  - Mark Archive as deprecated with note to use ArchiveWriter
  - Update touch and add commands to use ArchiveWriter
  - Update reader tests to use ArchiveWriter

## Test plan
- [x] Unit tests for compact (empty, duplicates, sorting, mode preservation)
- [x] All 71 unit tests pass
- [x] All pre-commit hooks pass (85.30% line coverage)

Closes #8