### PR TITLE
Add feature gates for reader, writer, and compact modules (#32)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,11 @@ path = "src/bin/bale/main.rs"
 required-features = ["bin"]
 
 [features]
-default = ["bin"]
-bin = ["dep:clap", "dep:env_logger"]
+default = ["reader", "writer", "compact", "bin"]
+reader = []
+writer = []
+compact = ["reader", "writer"]
+bin = ["compact", "dep:clap", "dep:env_logger"]
 
 [dependencies]
 # Core utilities

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,12 +2,20 @@
 //!
 //! A mmap-first, zero-copy zip-compatible archive format with fixed-stride
 //! entries for efficient random access.
+//!
+//! # Features
+//!
+//! - `reader` - Enables [`ArchiveReader`] for reading archives
+//! - `writer` - Enables [`ArchiveWriter`] for writing archives
+//! - `compact` - Enables [`compact`] and [`rename_duplicates`] functions (requires `reader` + `writer`)
+//! - `bin` - Enables the CLI binary (requires `compact`)
 
 /// Validated, normalized paths within a bale archive.
 mod archive_path;
 /// Central Directory Header for ZIP entries.
 mod central_dir;
 /// Archive compaction.
+#[cfg(feature = "compact")]
 mod compact;
 /// MS-DOS date/time format for ZIP archives.
 mod dos_time;
@@ -18,19 +26,24 @@ mod local_file;
 /// Memory-mapped file access.
 mod mmap;
 /// Zero-copy archive reader.
+#[cfg(feature = "reader")]
 mod reader;
 /// Unified archive tail (trailer) structures.
 pub mod tail;
 /// Append-only archive writer.
+#[cfg(feature = "writer")]
 mod writer;
 
 pub use archive_path::ArchivePath;
 pub use central_dir::CentralDirectoryHeader;
+#[cfg(feature = "compact")]
 pub use compact::{CompactStats, RenameStats, compact, rename_duplicates};
 pub use dos_time::DosDateTime;
 pub use error::BaleError;
 pub use local_file::LocalFileHeader;
 pub use mmap::{MappedArchive, MappedArchiveMut};
+#[cfg(feature = "reader")]
 pub use reader::ArchiveReader;
 pub use tail::{BaleEocd, Eocd, Trailer, Zip64Eocd, Zip64EocdLocator};
+#[cfg(feature = "writer")]
 pub use writer::ArchiveWriter;

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -347,7 +347,8 @@ impl ArchiveReader {
     }
 }
 
-#[cfg(test)]
+/// Tests require the `writer` feature to create test archives.
+#[cfg(all(test, feature = "writer"))]
 mod tests {
     use super::*;
 

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -434,7 +434,8 @@ impl ArchiveWriter {
     }
 }
 
-#[cfg(test)]
+/// Tests require the `reader` feature to verify written archives.
+#[cfg(all(test, feature = "reader"))]
 mod tests {
     use super::*;
     use tempfile::TempDir;


### PR DESCRIPTION
## Summary

Adds Cargo feature gates to allow users to disable modules independently:

| Feature | Default | Description | Dependencies |
|---------|---------|-------------|--------------|
| `reader` | ✓ | `ArchiveReader` for reading archives | None |
| `writer` | ✓ | `ArchiveWriter` for writing archives | None |
| `compact` | ✓ | `compact()` and `rename_duplicates()` | `reader` + `writer` |
| `bin` | ✓ | CLI binary | `compact` |

## Use Cases

- **Writer only**: Embedding bale archive creation in a build tool without needing read support
- **Reader only**: Read-only archive inspection tools  
- **No compact**: Applications that don't need archive maintenance operations

## Notes

- Core types (`BaleEocd`, `Trailer`, `CentralDirectoryHeader`, etc.) remain always available
- Tests with cross-dependencies are gated to only run when both features are enabled
- The existing `cargo check --no-default-features` pre-commit check verifies compilation

## Test plan

- [x] `cargo check --no-default-features` - Library with no features
- [x] `cargo check --no-default-features --features reader` - Reader only
- [x] `cargo check --no-default-features --features writer` - Writer only
- [x] `cargo check --no-default-features --features compact` - All lib features
- [x] `cargo build --all-features` - Full build with CLI
- [x] All pre-commit checks pass

Closes #32