### PR TITLE
Add directory awareness to core archive (#45)

### DIFF
--- a/src/archive/archive_read.rs
+++ b/src/archive/archive_read.rs
@@ -1,5 +1,6 @@
 //! Read operations trait for archives.
 
+use crate::archive::{DirEntry, Entry, FileEntry, SymlinkEntry};
 use crate::{ArchivePath, BaleEocd, BaleError, CentralDirectoryHeader};
 
 /// Read operations for archives.
@@ -40,6 +41,13 @@ pub trait ArchiveRead {
     ///
     /// The path comparison is byte-exact against the null-padded path.
     fn find_entry(&self, path: &str) -> Option<&CentralDirectoryHeader>;
+
+    /// Finds an entry by path and returns both header and trimmed path bytes.
+    ///
+    /// Like [`find_entry`](Self::find_entry), but also returns the path bytes
+    /// from the archive (with null padding removed). This is useful when you
+    /// need to construct an entry wrapper with the path borrowed from the archive.
+    fn find_entry_with_path(&self, path: &str) -> Option<(&CentralDirectoryHeader, &[u8])>;
 
     /// Returns a zero-copy slice of the file data for the given entry.
     ///
@@ -82,4 +90,61 @@ pub trait ArchiveRead {
     /// the last entry and the Central Directory. This can occur after
     /// deletions or when entries are shadowed.
     fn has_orphaned_data(&self) -> bool;
+
+    /// Returns a file entry by path.
+    ///
+    /// This method provides type-safe access to file entries without manual
+    /// kind checking. The path is normalized before lookup.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    /// - The path is not found ([`BaleError::EntryNotFound`])
+    /// - The entry exists but is not a file ([`BaleError::NotAFile`])
+    /// - The entry data cannot be read
+    fn file(&self, path: impl AsRef<str>) -> Result<FileEntry<'_>, BaleError>;
+
+    /// Returns a directory entry by path.
+    ///
+    /// This method provides type-safe access to directory entries without manual
+    /// kind checking. The path is normalized before lookup (trailing slashes
+    /// are handled automatically).
+    ///
+    /// Note: This only finds explicit directory entries. ZIP archives created
+    /// with standard tools include explicit directory entries. For implicit
+    /// directories (those that exist only because files have paths containing
+    /// them), this method returns `EntryNotFound`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    /// - The path is not found ([`BaleError::EntryNotFound`])
+    /// - The entry exists but is not a directory ([`BaleError::NotADirectory`])
+    fn folder(&self, path: impl AsRef<str>) -> Result<DirEntry<'_>, BaleError>;
+
+    /// Returns a symlink entry by path.
+    ///
+    /// This method provides type-safe access to symlink entries without manual
+    /// kind checking. The path is normalized before lookup.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    /// - The path is not found ([`BaleError::EntryNotFound`])
+    /// - The entry exists but is not a symlink ([`BaleError::NotASymlink`])
+    /// - The entry data cannot be read
+    fn symlink(&self, path: impl AsRef<str>) -> Result<SymlinkEntry<'_>, BaleError>;
+
+    /// Returns any entry by path.
+    ///
+    /// This method returns a generic [`Entry`] enum that can be matched on to
+    /// determine the entry type. Use this when you need to handle any type of
+    /// entry, or when you don't know the type ahead of time.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    /// - The path is not found ([`BaleError::EntryNotFound`])
+    /// - The entry data cannot be read (for files and symlinks)
+    fn entry(&self, path: impl AsRef<str>) -> Result<Entry<'_>, BaleError>;
 }

--- a/src/archive/archive_write.rs
+++ b/src/archive/archive_write.rs
@@ -71,4 +71,48 @@ pub trait ArchiveWrite: ArchiveRead {
     ///
     /// Returns an error if writing or syncing fails.
     fn sync(&mut self) -> Result<(), BaleError>;
+
+    /// Creates an explicit directory entry.
+    ///
+    /// Directory entries have zero-length data and directory mode bits set.
+    /// The path should not have a trailing slash; it will be added internally
+    /// if needed for ZIP compatibility.
+    ///
+    /// # Arguments
+    ///
+    /// * `path` - Archive path for the directory
+    /// * `mode` - Unix directory permissions (e.g., 0o755). The directory type
+    ///   bits (0o040000) will be added automatically if not present.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    /// - The path exceeds the archive's path_size
+    /// - Writing to the archive fails
+    fn add_folder(&mut self, path: impl AsRef<str>, mode: u32) -> Result<(), BaleError>;
+
+    /// Creates a symbolic link entry.
+    ///
+    /// Symlink entries store the target path as their data, with symlink mode
+    /// bits set in external attributes.
+    ///
+    /// # Arguments
+    ///
+    /// * `path` - Archive path for the symlink
+    /// * `target` - The symlink target (what the link points to)
+    /// * `mode` - Unix permissions (e.g., 0o777). The symlink type bits
+    ///   (0o120000) will be added automatically if not present.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    /// - The path exceeds the archive's path_size
+    /// - The target length exceeds 4GB
+    /// - Writing to the archive fails
+    fn add_symlink(
+        &mut self,
+        path: impl AsRef<str>,
+        target: impl AsRef<str>,
+        mode: u32,
+    ) -> Result<(), BaleError>;
 }

--- a/src/archive/dir_entry.rs
+++ b/src/archive/dir_entry.rs
@@ -1,0 +1,49 @@
+//! Directory entry wrapper for ergonomic access.
+
+use crate::{ArchivePath, CentralDirectoryHeader, DosDateTime};
+
+/// A directory entry in the archive.
+///
+/// This struct wraps a Central Directory header for an explicit directory entry.
+/// Note that ZIP archives may have implicit directories (directories that exist
+/// only because files have paths containing them). This struct only represents
+/// explicit directory entries that were stored in the archive.
+///
+/// # Lifetime
+///
+/// The lifetime `'a` is tied to the archive that created this entry.
+#[derive(Debug)]
+pub struct DirEntry<'a> {
+    /// The Central Directory header for this directory.
+    pub(crate) header: &'a CentralDirectoryHeader,
+    /// The directory path (without null padding or trailing slash).
+    pub(crate) path: ArchivePath<'a>,
+}
+
+impl<'a> DirEntry<'a> {
+    /// Returns the directory path.
+    #[must_use]
+    pub fn path(&self) -> &ArchivePath<'a> {
+        &self.path
+    }
+
+    /// Returns the Unix mode (file type and permissions).
+    ///
+    /// The mode is extracted from the upper 16 bits of `external_attrs`.
+    #[must_use]
+    pub fn mode(&self) -> u32 {
+        self.header.external_attrs.get() >> 16
+    }
+
+    /// Returns the modification time.
+    #[must_use]
+    pub fn mtime(&self) -> DosDateTime {
+        DosDateTime::from_date_time_parts(self.header.mod_date.get(), self.header.mod_time.get())
+    }
+
+    /// Returns a reference to the Central Directory header.
+    #[must_use]
+    pub fn header(&self) -> &'a CentralDirectoryHeader {
+        self.header
+    }
+}

--- a/src/archive/entry.rs
+++ b/src/archive/entry.rs
@@ -1,0 +1,121 @@
+//! Generic entry wrapper for any archive entry type.
+
+use crate::archive::{DirEntry, FileEntry, SymlinkEntry};
+
+/// An entry in the archive of any type.
+///
+/// This enum provides generic access to archive entries when the caller
+/// needs to handle any entry type. For type-specific access, use
+/// [`ArchiveRead::file`], [`ArchiveRead::folder`], or the entry's
+/// conversion methods.
+///
+/// # Example
+///
+/// ```ignore
+/// match archive.entry("some/path")? {
+///     Entry::File(f) => println!("file: {} bytes", f.size()),
+///     Entry::Directory(d) => println!("dir: {}", d.path()),
+///     Entry::Symlink(s) => println!("link -> {}", s.target().unwrap_or("<binary>")),
+/// }
+/// ```
+#[derive(Debug)]
+pub enum Entry<'a> {
+    /// A regular file entry.
+    File(FileEntry<'a>),
+    /// A directory entry.
+    Directory(DirEntry<'a>),
+    /// A symbolic link entry.
+    Symlink(SymlinkEntry<'a>),
+}
+
+impl<'a> Entry<'a> {
+    /// Returns `true` if this is a file entry.
+    #[must_use]
+    pub fn is_file(&self) -> bool {
+        matches!(self, Self::File(_))
+    }
+
+    /// Returns `true` if this is a directory entry.
+    #[must_use]
+    pub fn is_directory(&self) -> bool {
+        matches!(self, Self::Directory(_))
+    }
+
+    /// Returns `true` if this is a symlink entry.
+    #[must_use]
+    pub fn is_symlink(&self) -> bool {
+        matches!(self, Self::Symlink(_))
+    }
+
+    /// Returns the file entry if this is a file, or `None` otherwise.
+    #[must_use]
+    pub fn as_file(&self) -> Option<&FileEntry<'a>> {
+        match self {
+            Self::File(f) => Some(f),
+            _ => None,
+        }
+    }
+
+    /// Returns the directory entry if this is a directory, or `None` otherwise.
+    #[must_use]
+    pub fn as_directory(&self) -> Option<&DirEntry<'a>> {
+        match self {
+            Self::Directory(d) => Some(d),
+            _ => None,
+        }
+    }
+
+    /// Returns the symlink entry if this is a symlink, or `None` otherwise.
+    #[must_use]
+    pub fn as_symlink(&self) -> Option<&SymlinkEntry<'a>> {
+        match self {
+            Self::Symlink(s) => Some(s),
+            _ => None,
+        }
+    }
+
+    /// Converts into a file entry if this is a file, or `None` otherwise.
+    #[must_use]
+    pub fn into_file(self) -> Option<FileEntry<'a>> {
+        match self {
+            Self::File(f) => Some(f),
+            _ => None,
+        }
+    }
+
+    /// Converts into a directory entry if this is a directory, or `None` otherwise.
+    #[must_use]
+    pub fn into_directory(self) -> Option<DirEntry<'a>> {
+        match self {
+            Self::Directory(d) => Some(d),
+            _ => None,
+        }
+    }
+
+    /// Converts into a symlink entry if this is a symlink, or `None` otherwise.
+    #[must_use]
+    pub fn into_symlink(self) -> Option<SymlinkEntry<'a>> {
+        match self {
+            Self::Symlink(s) => Some(s),
+            _ => None,
+        }
+    }
+}
+
+impl<'a> From<FileEntry<'a>> for Entry<'a> {
+    fn from(entry: FileEntry<'a>) -> Self {
+        Self::File(entry)
+    }
+}
+
+impl<'a> From<DirEntry<'a>> for Entry<'a> {
+    fn from(entry: DirEntry<'a>) -> Self {
+        Self::Directory(entry)
+    }
+}
+
+impl<'a> From<SymlinkEntry<'a>> for Entry<'a> {
+    fn from(entry: SymlinkEntry<'a>) -> Self {
+        Self::Symlink(entry)
+    }
+}

--- a/src/archive/file_entry.rs
+++ b/src/archive/file_entry.rs
@@ -1,0 +1,68 @@
+//! File entry wrapper for ergonomic access.
+
+use crate::{ArchivePath, CentralDirectoryHeader, DosDateTime};
+
+/// A file entry in the archive.
+///
+/// This struct wraps a Central Directory header and provides convenient
+/// access to file metadata and data. The data is pre-resolved for ergonomics.
+///
+/// # Lifetime
+///
+/// The lifetime `'a` is tied to the archive that created this entry.
+/// All borrowed data (path, header, file data) remains valid for this lifetime.
+#[derive(Debug)]
+pub struct FileEntry<'a> {
+    /// The Central Directory header for this file.
+    pub(crate) header: &'a CentralDirectoryHeader,
+    /// The file path (without null padding).
+    pub(crate) path: ArchivePath<'a>,
+    /// The file data.
+    pub(crate) data: &'a [u8],
+}
+
+impl<'a> FileEntry<'a> {
+    /// Returns the file data.
+    #[must_use]
+    pub fn data(&self) -> &'a [u8] {
+        self.data
+    }
+
+    /// Returns the uncompressed file size in bytes.
+    #[must_use]
+    pub fn size(&self) -> u64 {
+        self.header.uncompressed_size.get() as u64
+    }
+
+    /// Returns the CRC-32 checksum of the file data.
+    #[must_use]
+    pub fn crc32(&self) -> u32 {
+        self.header.crc32.get()
+    }
+
+    /// Returns the file path.
+    #[must_use]
+    pub fn path(&self) -> &ArchivePath<'a> {
+        &self.path
+    }
+
+    /// Returns the Unix mode (file type and permissions).
+    ///
+    /// The mode is extracted from the upper 16 bits of `external_attrs`.
+    #[must_use]
+    pub fn mode(&self) -> u32 {
+        self.header.external_attrs.get() >> 16
+    }
+
+    /// Returns the modification time.
+    #[must_use]
+    pub fn mtime(&self) -> DosDateTime {
+        DosDateTime::from_date_time_parts(self.header.mod_date.get(), self.header.mod_time.get())
+    }
+
+    /// Returns a reference to the Central Directory header.
+    #[must_use]
+    pub fn header(&self) -> &'a CentralDirectoryHeader {
+        self.header
+    }
+}

--- a/src/archive/mod.rs
+++ b/src/archive/mod.rs
@@ -16,11 +16,23 @@ mod archive_write;
 /// Core archive struct.
 /// Named `core` instead of `archive` to avoid module inception (clippy::module_inception).
 mod core;
+/// Directory entry wrapper.
+mod dir_entry;
+/// Generic entry enum.
+mod entry;
+/// File entry wrapper.
+mod file_entry;
 /// Read-only archive implementation.
 mod reader;
+/// Symlink entry wrapper.
+mod symlink_entry;
 /// Read-write archive implementation.
 mod writer;
 
 pub use archive_read::ArchiveRead;
 pub use archive_write::ArchiveWrite;
 pub use core::{Archive, ArchiveReader, ArchiveWriter};
+pub use dir_entry::DirEntry;
+pub use entry::Entry;
+pub use file_entry::FileEntry;
+pub use symlink_entry::SymlinkEntry;

--- a/src/archive/reader.rs
+++ b/src/archive/reader.rs
@@ -1,10 +1,10 @@
 //! Read-only archive implementation.
 
-use super::{Archive, ArchiveRead};
+use super::{Archive, ArchiveRead, DirEntry, Entry, FileEntry, SymlinkEntry};
 use crate::central_dir::parse_cd_entries;
 use crate::{
-    ArchivePath, BaleEocd, BaleError, CentralDirectoryHeader, Eocd, LocalFileHeader, MappedArchive,
-    Trailer, Zip64Eocd,
+    ArchivePath, BaleEocd, BaleError, CentralDirectoryHeader, EntryKind, Eocd, LocalFileHeader,
+    MappedArchive, Trailer, Zip64Eocd,
 };
 use std::collections::HashSet;
 use std::path::Path;
@@ -134,6 +134,10 @@ impl ArchiveRead for Archive<MappedArchive> {
     }
 
     fn find_entry(&self, path: &str) -> Option<&CentralDirectoryHeader> {
+        self.find_entry_with_path(path).map(|(h, _)| h)
+    }
+
+    fn find_entry_with_path(&self, path: &str) -> Option<(&CentralDirectoryHeader, &[u8])> {
         let path_bytes = path.as_bytes();
         let path_size = self.path_size();
 
@@ -146,7 +150,13 @@ impl ArchiveRead for Archive<MappedArchive> {
             if entry.path.starts_with(path_bytes)
                 && entry.path[path_bytes.len()..].iter().all(|&b| b == 0)
             {
-                result = Some(&entry.header);
+                // Trim null padding from the stored path.
+                let end = entry
+                    .path
+                    .iter()
+                    .position(|&b| b == 0)
+                    .unwrap_or(entry.path.len());
+                result = Some((&entry.header, &entry.path[..end]));
             }
         }
         result
@@ -266,5 +276,139 @@ impl ArchiveRead for Archive<MappedArchive> {
         }
 
         expected_offset != cd_offset
+    }
+
+    fn file(&self, path: impl AsRef<str>) -> Result<FileEntry<'_>, BaleError> {
+        let path_str = path.as_ref();
+        let (header, path_bytes) = self
+            .find_entry_with_path(path_str)
+            .ok_or_else(|| BaleError::EntryNotFound(path_str.to_string()))?;
+
+        if header.kind() != EntryKind::File {
+            return Err(BaleError::NotAFile(path_str.to_string()));
+        }
+
+        let data = self.read_data(header)?;
+        let archive_path = ArchivePath::from_bytes(path_bytes);
+
+        Ok(FileEntry {
+            header,
+            path: archive_path,
+            data,
+        })
+    }
+
+    fn folder(&self, path: impl AsRef<str>) -> Result<DirEntry<'_>, BaleError> {
+        let path_str = path.as_ref();
+
+        // Try with and without trailing slash.
+        let found = self.find_entry_with_path(path_str).or_else(|| {
+            if path_str.ends_with('/') {
+                self.find_entry_with_path(path_str.trim_end_matches('/'))
+            } else {
+                self.find_entry_with_path(&format!("{path_str}/"))
+            }
+        });
+
+        let (header, path_bytes) =
+            found.ok_or_else(|| BaleError::EntryNotFound(path_str.to_string()))?;
+
+        if header.kind() != EntryKind::Directory {
+            return Err(BaleError::NotADirectory(path_str.to_string()));
+        }
+
+        // Trim trailing slash for the ArchivePath.
+        let trimmed = if path_bytes.ends_with(b"/") {
+            &path_bytes[..path_bytes.len() - 1]
+        } else {
+            path_bytes
+        };
+        let archive_path = ArchivePath::from_bytes(trimmed);
+
+        Ok(DirEntry {
+            header,
+            path: archive_path,
+        })
+    }
+
+    fn symlink(&self, path: impl AsRef<str>) -> Result<SymlinkEntry<'_>, BaleError> {
+        let path_str = path.as_ref();
+        let (header, path_bytes) = self
+            .find_entry_with_path(path_str)
+            .ok_or_else(|| BaleError::EntryNotFound(path_str.to_string()))?;
+
+        if header.kind() != EntryKind::Symlink {
+            return Err(BaleError::NotASymlink(path_str.to_string()));
+        }
+
+        let target = self.read_data(header)?;
+        let archive_path = ArchivePath::from_bytes(path_bytes);
+
+        Ok(SymlinkEntry {
+            header,
+            path: archive_path,
+            target,
+        })
+    }
+
+    fn entry(&self, path: impl AsRef<str>) -> Result<Entry<'_>, BaleError> {
+        let path_str = path.as_ref();
+
+        // Try direct lookup first.
+        let found = self.find_entry_with_path(path_str).or_else(|| {
+            // For directories, also try with/without trailing slash.
+            if path_str.ends_with('/') {
+                self.find_entry_with_path(path_str.trim_end_matches('/'))
+            } else {
+                self.find_entry_with_path(&format!("{path_str}/"))
+            }
+        });
+
+        let (header, path_bytes) =
+            found.ok_or_else(|| BaleError::EntryNotFound(path_str.to_string()))?;
+
+        match header.kind() {
+            EntryKind::File => {
+                let data = self.read_data(header)?;
+                let archive_path = ArchivePath::from_bytes(path_bytes);
+                Ok(Entry::File(FileEntry {
+                    header,
+                    path: archive_path,
+                    data,
+                }))
+            }
+            EntryKind::Directory => {
+                // Trim trailing slash for the ArchivePath.
+                let trimmed = if path_bytes.ends_with(b"/") {
+                    &path_bytes[..path_bytes.len() - 1]
+                } else {
+                    path_bytes
+                };
+                let archive_path = ArchivePath::from_bytes(trimmed);
+                Ok(Entry::Directory(DirEntry {
+                    header,
+                    path: archive_path,
+                }))
+            }
+            EntryKind::Symlink => {
+                let target = self.read_data(header)?;
+                let archive_path = ArchivePath::from_bytes(path_bytes);
+                Ok(Entry::Symlink(SymlinkEntry {
+                    header,
+                    path: archive_path,
+                    target,
+                }))
+            }
+            EntryKind::Other(_) => {
+                // Treat unknown types as files for now.
+                let data = self.read_data(header)?;
+                let archive_path = ArchivePath::from_bytes(path_bytes);
+                Ok(Entry::File(FileEntry {
+                    header,
+                    path: archive_path,
+                    data,
+                }))
+            }
+        }
     }
 }

--- a/src/archive/symlink_entry.rs
+++ b/src/archive/symlink_entry.rs
@@ -1,0 +1,66 @@
+//! Symlink entry wrapper for ergonomic access.
+
+use crate::{ArchivePath, CentralDirectoryHeader, DosDateTime};
+
+/// A symbolic link entry in the archive.
+///
+/// This struct wraps a Central Directory header for a symlink entry and
+/// provides convenient access to the link metadata and target.
+///
+/// # Lifetime
+///
+/// The lifetime `'a` is tied to the archive that created this entry.
+/// All borrowed data (path, header, target) remains valid for this lifetime.
+#[derive(Debug)]
+pub struct SymlinkEntry<'a> {
+    /// The Central Directory header for this symlink.
+    pub(crate) header: &'a CentralDirectoryHeader,
+    /// The symlink path (without null padding).
+    pub(crate) path: ArchivePath<'a>,
+    /// The symlink target (stored as file data).
+    pub(crate) target: &'a [u8],
+}
+
+impl<'a> SymlinkEntry<'a> {
+    /// Returns the symlink target as bytes.
+    ///
+    /// The target is stored as the file data of the symlink entry.
+    #[must_use]
+    pub fn target_bytes(&self) -> &'a [u8] {
+        self.target
+    }
+
+    /// Returns the symlink target as a string, if valid UTF-8.
+    ///
+    /// Returns `None` if the target is not valid UTF-8.
+    #[must_use]
+    pub fn target(&self) -> Option<&'a str> {
+        std::str::from_utf8(self.target).ok()
+    }
+
+    /// Returns the symlink path.
+    #[must_use]
+    pub fn path(&self) -> &ArchivePath<'a> {
+        &self.path
+    }
+
+    /// Returns the Unix mode (file type and permissions).
+    ///
+    /// The mode is extracted from the upper 16 bits of `external_attrs`.
+    #[must_use]
+    pub fn mode(&self) -> u32 {
+        self.header.external_attrs.get() >> 16
+    }
+
+    /// Returns the modification time.
+    #[must_use]
+    pub fn mtime(&self) -> DosDateTime {
+        DosDateTime::from_date_time_parts(self.header.mod_date.get(), self.header.mod_time.get())
+    }
+
+    /// Returns a reference to the Central Directory header.
+    #[must_use]
+    pub fn header(&self) -> &'a CentralDirectoryHeader {
+        self.header
+    }
+}

--- a/src/archive/writer.rs
+++ b/src/archive/writer.rs
@@ -1,10 +1,10 @@
 //! Read-write archive implementation.
 
-use super::{Archive, ArchiveRead, ArchiveWrite};
+use super::{Archive, ArchiveRead, ArchiveWrite, DirEntry, Entry, FileEntry, SymlinkEntry};
 use crate::central_dir::{CdEntry, parse_cd_entries};
 use crate::{
-    ArchivePath, BaleEocd, BaleError, CentralDirectoryHeader, DosDateTime, Eocd, LocalFileHeader,
-    MappedArchiveMut, Trailer, Zip64Eocd,
+    ArchivePath, BaleEocd, BaleError, CentralDirectoryHeader, DosDateTime, EntryKind, Eocd,
+    LocalFileHeader, MappedArchiveMut, Trailer, Zip64Eocd,
 };
 use std::collections::HashSet;
 use std::fs::File;
@@ -158,6 +158,10 @@ impl ArchiveRead for Archive<MappedArchiveMut> {
     }
 
     fn find_entry(&self, path: &str) -> Option<&CentralDirectoryHeader> {
+        self.find_entry_with_path(path).map(|(h, _)| h)
+    }
+
+    fn find_entry_with_path(&self, path: &str) -> Option<(&CentralDirectoryHeader, &[u8])> {
         let path_bytes = path.as_bytes();
         let path_size = self.path_size();
 
@@ -170,7 +174,13 @@ impl ArchiveRead for Archive<MappedArchiveMut> {
             if entry.path.starts_with(path_bytes)
                 && entry.path[path_bytes.len()..].iter().all(|&b| b == 0)
             {
-                result = Some(&entry.header);
+                // Trim null padding from the stored path.
+                let end = entry
+                    .path
+                    .iter()
+                    .position(|&b| b == 0)
+                    .unwrap_or(entry.path.len());
+                result = Some((&entry.header, &entry.path[..end]));
             }
         }
         result
@@ -288,6 +298,140 @@ impl ArchiveRead for Archive<MappedArchiveMut> {
         }
 
         expected_offset != self.write_offset
+    }
+
+    fn file(&self, path: impl AsRef<str>) -> Result<FileEntry<'_>, BaleError> {
+        let path_str = path.as_ref();
+        let (header, path_bytes) = self
+            .find_entry_with_path(path_str)
+            .ok_or_else(|| BaleError::EntryNotFound(path_str.to_string()))?;
+
+        if header.kind() != EntryKind::File {
+            return Err(BaleError::NotAFile(path_str.to_string()));
+        }
+
+        let data = self.read_data(header)?;
+        let archive_path = ArchivePath::from_bytes(path_bytes);
+
+        Ok(FileEntry {
+            header,
+            path: archive_path,
+            data,
+        })
+    }
+
+    fn folder(&self, path: impl AsRef<str>) -> Result<DirEntry<'_>, BaleError> {
+        let path_str = path.as_ref();
+
+        // Try with and without trailing slash.
+        let found = self.find_entry_with_path(path_str).or_else(|| {
+            if path_str.ends_with('/') {
+                self.find_entry_with_path(path_str.trim_end_matches('/'))
+            } else {
+                self.find_entry_with_path(&format!("{path_str}/"))
+            }
+        });
+
+        let (header, path_bytes) =
+            found.ok_or_else(|| BaleError::EntryNotFound(path_str.to_string()))?;
+
+        if header.kind() != EntryKind::Directory {
+            return Err(BaleError::NotADirectory(path_str.to_string()));
+        }
+
+        // Trim trailing slash for the ArchivePath.
+        let trimmed = if path_bytes.ends_with(b"/") {
+            &path_bytes[..path_bytes.len() - 1]
+        } else {
+            path_bytes
+        };
+        let archive_path = ArchivePath::from_bytes(trimmed);
+
+        Ok(DirEntry {
+            header,
+            path: archive_path,
+        })
+    }
+
+    fn symlink(&self, path: impl AsRef<str>) -> Result<SymlinkEntry<'_>, BaleError> {
+        let path_str = path.as_ref();
+        let (header, path_bytes) = self
+            .find_entry_with_path(path_str)
+            .ok_or_else(|| BaleError::EntryNotFound(path_str.to_string()))?;
+
+        if header.kind() != EntryKind::Symlink {
+            return Err(BaleError::NotASymlink(path_str.to_string()));
+        }
+
+        let target = self.read_data(header)?;
+        let archive_path = ArchivePath::from_bytes(path_bytes);
+
+        Ok(SymlinkEntry {
+            header,
+            path: archive_path,
+            target,
+        })
+    }
+
+    fn entry(&self, path: impl AsRef<str>) -> Result<Entry<'_>, BaleError> {
+        let path_str = path.as_ref();
+
+        // Try direct lookup first.
+        let found = self.find_entry_with_path(path_str).or_else(|| {
+            // For directories, also try with/without trailing slash.
+            if path_str.ends_with('/') {
+                self.find_entry_with_path(path_str.trim_end_matches('/'))
+            } else {
+                self.find_entry_with_path(&format!("{path_str}/"))
+            }
+        });
+
+        let (header, path_bytes) =
+            found.ok_or_else(|| BaleError::EntryNotFound(path_str.to_string()))?;
+
+        match header.kind() {
+            EntryKind::File => {
+                let data = self.read_data(header)?;
+                let archive_path = ArchivePath::from_bytes(path_bytes);
+                Ok(Entry::File(FileEntry {
+                    header,
+                    path: archive_path,
+                    data,
+                }))
+            }
+            EntryKind::Directory => {
+                // Trim trailing slash for the ArchivePath.
+                let trimmed = if path_bytes.ends_with(b"/") {
+                    &path_bytes[..path_bytes.len() - 1]
+                } else {
+                    path_bytes
+                };
+                let archive_path = ArchivePath::from_bytes(trimmed);
+                Ok(Entry::Directory(DirEntry {
+                    header,
+                    path: archive_path,
+                }))
+            }
+            EntryKind::Symlink => {
+                let target = self.read_data(header)?;
+                let archive_path = ArchivePath::from_bytes(path_bytes);
+                Ok(Entry::Symlink(SymlinkEntry {
+                    header,
+                    path: archive_path,
+                    target,
+                }))
+            }
+            EntryKind::Other(_) => {
+                // Treat unknown types as files for now.
+                let data = self.read_data(header)?;
+                let archive_path = ArchivePath::from_bytes(path_bytes);
+                Ok(Entry::File(FileEntry {
+                    header,
+                    path: archive_path,
+                    data,
+                }))
+            }
+        }
     }
 }
 
@@ -451,6 +595,50 @@ impl ArchiveWrite for Archive<MappedArchiveMut> {
 
         self.dirty = false;
         Ok(())
+    }
+
+    fn add_folder(&mut self, path: impl AsRef<str>, mode: u32) -> Result<(), BaleError> {
+        let path_str = path.as_ref();
+
+        // Ensure directory mode bits are set.
+        const S_IFDIR: u32 = 0o040000;
+        let mode = if mode & 0o170000 == 0 {
+            // No file type bits set, add directory bits.
+            mode | S_IFDIR
+        } else {
+            mode
+        };
+
+        // Directories have empty data and a trailing slash in their path.
+        let dir_path = if path_str.ends_with('/') {
+            path_str.to_string()
+        } else {
+            format!("{path_str}/")
+        };
+
+        self.add_entry(&dir_path, &[], mode)
+    }
+
+    fn add_symlink(
+        &mut self,
+        path: impl AsRef<str>,
+        target: impl AsRef<str>,
+        mode: u32,
+    ) -> Result<(), BaleError> {
+        let path_str = path.as_ref();
+        let target_str = target.as_ref();
+
+        // Ensure symlink mode bits are set.
+        const S_IFLNK: u32 = 0o120000;
+        let mode = if mode & 0o170000 == 0 {
+            // No file type bits set, add symlink bits.
+            mode | S_IFLNK
+        } else {
+            mode
+        };
+
+        // Symlink target is stored as file data.
+        self.add_entry(path_str, target_str.as_bytes(), mode)
     }
 }
 

--- a/src/central_dir/header.rs
+++ b/src/central_dir/header.rs
@@ -3,7 +3,7 @@
 use zerocopy::byteorder::little_endian::{U16, U32};
 use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout, Unaligned};
 
-use crate::DosDateTime;
+use crate::{DosDateTime, EntryKind};
 
 /// Central Directory File Header (46 bytes fixed, followed by filename).
 ///
@@ -80,6 +80,16 @@ impl CentralDirectoryHeader {
     #[must_use]
     pub const fn stride(path_size: usize) -> usize {
         Self::SIZE.saturating_add(path_size)
+    }
+
+    /// Returns the entry kind based on Unix mode bits in external_attrs.
+    ///
+    /// Extracts the file type from the upper 16 bits of `external_attrs`
+    /// and returns the corresponding [`EntryKind`].
+    #[must_use]
+    pub fn kind(&self) -> EntryKind {
+        let mode = self.external_attrs.get() >> 16;
+        EntryKind::from_mode(mode)
     }
 
     /// Creates a new `CentralDirectoryHeader` for an uncompressed file.
@@ -191,6 +201,34 @@ mod tests {
             BaleEocd::DEFAULT_PATH_SIZE,
         );
         assert_eq!(header.external_attrs.get(), UNIX_MODE_EXEC << 16);
+    }
+
+    /// kind() returns File for regular file mode.
+    #[test]
+    fn kind_returns_file() {
+        let header = CentralDirectoryHeader::new(
+            100,
+            0,
+            DosDateTime::default(),
+            0,
+            0o100644, // Regular file with rw-r--r--
+            BaleEocd::DEFAULT_PATH_SIZE,
+        );
+        assert_eq!(header.kind(), crate::EntryKind::File);
+    }
+
+    /// kind() returns Directory for directory mode.
+    #[test]
+    fn kind_returns_directory() {
+        let header = CentralDirectoryHeader::new(
+            0,
+            0,
+            DosDateTime::default(),
+            0,
+            0o040755, // Directory with rwxr-xr-x
+            BaleEocd::DEFAULT_PATH_SIZE,
+        );
+        assert_eq!(header.kind(), crate::EntryKind::Directory);
     }
 
     /// Header can be serialized and deserialized without data loss.

--- a/src/compact.rs
+++ b/src/compact.rs
@@ -1,6 +1,8 @@
 //! Archive compaction to reclaim space from orphaned data.
 
-use crate::{ArchivePath, ArchiveRead, ArchiveReader, ArchiveWrite, ArchiveWriter, BaleError};
+use crate::{
+    ArchivePath, ArchiveRead, ArchiveReader, ArchiveWrite, ArchiveWriter, BaleError, EntryKind,
+};
 use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -102,6 +104,40 @@ pub fn compact(path: impl AsRef<Path>) -> Result<CompactStats, BaleError> {
     }
     final_entries.reverse();
 
+    // Collect explicit directory paths (without trailing slashes).
+    let explicit_dirs: HashSet<Vec<u8>> = final_entries
+        .iter()
+        .filter(|(header, _)| header.kind() == EntryKind::Directory)
+        .map(|(_, path_bytes)| {
+            let trimmed: Vec<u8> = path_bytes.iter().copied().take_while(|&b| b != 0).collect();
+            // Remove trailing slash if present.
+            if trimmed.ends_with(b"/") {
+                trimmed[..trimmed.len() - 1].to_vec()
+            } else {
+                trimmed
+            }
+        })
+        .collect();
+
+    // Collect all implicit directories from file paths.
+    let mut missing_dirs: HashSet<Vec<u8>> = HashSet::new();
+    for (_, path_bytes) in &final_entries {
+        let trimmed: Vec<u8> = path_bytes.iter().copied().take_while(|&b| b != 0).collect();
+
+        // Extract all parent directories from this path.
+        let mut parent = trimmed.as_slice();
+        while let Some(pos) = parent.iter().rposition(|&b| b == b'/') {
+            parent = &parent[..pos];
+            if parent.is_empty() {
+                break;
+            }
+            let parent_vec = parent.to_vec();
+            if !explicit_dirs.contains(&parent_vec) {
+                missing_dirs.insert(parent_vec);
+            }
+        }
+    }
+
     // Sort by path for binary search.
     final_entries.sort_by(|a, b| a.1.cmp(&b.1));
 
@@ -121,6 +157,17 @@ pub fn compact(path: impl AsRef<Path>) -> Result<CompactStats, BaleError> {
     // Write compacted archive.
     {
         let mut writer = ArchiveWriter::create_with_options(&temp_path, alignment, path_size)?;
+
+        // First, add any missing directory entries.
+        // Sort them to ensure parent directories come before children.
+        let mut missing_dirs_sorted: Vec<_> = missing_dirs.into_iter().collect();
+        missing_dirs_sorted.sort();
+
+        for dir_bytes in &missing_dirs_sorted {
+            let dir_str = std::str::from_utf8(dir_bytes)?;
+            // Use default directory mode (rwxr-xr-x).
+            writer.add_folder(dir_str, 0o755)?;
+        }
 
         for (header, path_bytes) in &final_entries {
             // Read the data from the original archive.

--- a/src/entry_kind.rs
+++ b/src/entry_kind.rs
@@ -1,0 +1,147 @@
+//! Entry type classification based on Unix mode bits.
+
+/// Entry type based on Unix mode bits in external_attrs.
+///
+/// ZIP archives store Unix file type and permissions in the upper 16 bits
+/// of the `external_attrs` field. This enum represents the file type portion.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum EntryKind {
+    /// Regular file (S_IFREG).
+    File,
+    /// Directory (S_IFDIR).
+    Directory,
+    /// Symbolic link (S_IFLNK).
+    Symlink,
+    /// Unknown or unsupported file type.
+    ///
+    /// Contains the raw file type bits (masked with S_IFMT).
+    Other(u32),
+}
+
+impl EntryKind {
+    /// Unix file type mask (S_IFMT).
+    const S_IFMT: u32 = 0o170000;
+
+    /// Regular file (S_IFREG).
+    const S_IFREG: u32 = 0o100000;
+
+    /// Directory (S_IFDIR).
+    const S_IFDIR: u32 = 0o040000;
+
+    /// Symbolic link (S_IFLNK).
+    const S_IFLNK: u32 = 0o120000;
+
+    /// Determines entry kind from Unix mode bits.
+    ///
+    /// Extracts the file type from the mode and returns the corresponding
+    /// `EntryKind`. Unrecognized types are returned as `Other`.
+    #[must_use]
+    pub fn from_mode(mode: u32) -> Self {
+        match mode & Self::S_IFMT {
+            Self::S_IFREG => Self::File,
+            Self::S_IFDIR => Self::Directory,
+            Self::S_IFLNK => Self::Symlink,
+            // Mode 0 (no type bits) defaults to File for compatibility.
+            // Many ZIP tools don't set type bits for regular files.
+            0 => Self::File,
+            other => Self::Other(other),
+        }
+    }
+
+    /// Returns true if this is a regular file.
+    #[must_use]
+    pub fn is_file(&self) -> bool {
+        matches!(self, Self::File)
+    }
+
+    /// Returns true if this is a directory.
+    #[must_use]
+    pub fn is_directory(&self) -> bool {
+        matches!(self, Self::Directory)
+    }
+
+    /// Returns true if this is a symbolic link.
+    #[must_use]
+    pub fn is_symlink(&self) -> bool {
+        matches!(self, Self::Symlink)
+    }
+}
+
+impl std::fmt::Display for EntryKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::File => write!(f, "file"),
+            Self::Directory => write!(f, "directory"),
+            Self::Symlink => write!(f, "symlink"),
+            Self::Other(mode) => write!(f, "unknown({mode:#o})"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Regular file mode bits are recognized.
+    #[test]
+    fn file_mode() {
+        assert_eq!(EntryKind::from_mode(0o100644), EntryKind::File);
+        assert_eq!(EntryKind::from_mode(0o100755), EntryKind::File);
+    }
+
+    /// Directory mode bits are recognized.
+    #[test]
+    fn directory_mode() {
+        assert_eq!(EntryKind::from_mode(0o040755), EntryKind::Directory);
+        assert_eq!(EntryKind::from_mode(0o040000), EntryKind::Directory);
+    }
+
+    /// Symlink mode bits are recognized.
+    #[test]
+    fn symlink_mode() {
+        assert_eq!(EntryKind::from_mode(0o120777), EntryKind::Symlink);
+        assert_eq!(EntryKind::from_mode(0o120000), EntryKind::Symlink);
+    }
+
+    /// Zero mode defaults to file for compatibility.
+    #[test]
+    fn zero_mode_defaults_to_file() {
+        assert_eq!(EntryKind::from_mode(0), EntryKind::File);
+    }
+
+    /// Unknown mode bits are captured in Other.
+    #[test]
+    fn unknown_mode() {
+        // Block device (S_IFBLK = 0o060000)
+        let kind = EntryKind::from_mode(0o060644);
+        assert_eq!(kind, EntryKind::Other(0o060000));
+    }
+
+    /// is_* predicates work correctly.
+    #[test]
+    fn predicates() {
+        assert!(EntryKind::File.is_file());
+        assert!(!EntryKind::File.is_directory());
+        assert!(!EntryKind::File.is_symlink());
+
+        assert!(!EntryKind::Directory.is_file());
+        assert!(EntryKind::Directory.is_directory());
+        assert!(!EntryKind::Directory.is_symlink());
+
+        assert!(!EntryKind::Symlink.is_file());
+        assert!(!EntryKind::Symlink.is_directory());
+        assert!(EntryKind::Symlink.is_symlink());
+    }
+
+    /// Display formatting.
+    #[test]
+    fn display() {
+        assert_eq!(format!("{}", EntryKind::File), "file");
+        assert_eq!(format!("{}", EntryKind::Directory), "directory");
+        assert_eq!(format!("{}", EntryKind::Symlink), "symlink");
+        assert_eq!(
+            format!("{}", EntryKind::Other(0o060000)),
+            "unknown(0o60000)"
+        );
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -54,6 +54,18 @@ pub enum BaleError {
     #[error("entry not found: {0}")]
     EntryNotFound(String),
 
+    /// Entry exists but is not a file.
+    #[error("not a file: {0}")]
+    NotAFile(String),
+
+    /// Entry exists but is not a directory.
+    #[error("not a directory: {0}")]
+    NotADirectory(String),
+
+    /// Entry exists but is not a symlink.
+    #[error("not a symlink: {0}")]
+    NotASymlink(String),
+
     /// Archive data is corrupted or invalid.
     #[error("corrupted archive: {0}")]
     Corrupted(String),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,8 @@ mod central_dir;
 mod compact;
 /// MS-DOS date/time format for ZIP archives.
 mod dos_time;
+/// Entry type classification.
+mod entry_kind;
 /// Error types for bale operations.
 mod error;
 /// Local File Header for ZIP entries.
@@ -34,7 +36,7 @@ pub mod tail;
 #[cfg(feature = "reader")]
 pub use archive::ArchiveReader;
 #[cfg(any(feature = "reader", feature = "writer"))]
-pub use archive::{Archive, ArchiveRead};
+pub use archive::{Archive, ArchiveRead, DirEntry, Entry, FileEntry, SymlinkEntry};
 #[cfg(feature = "writer")]
 pub use archive::{ArchiveWrite, ArchiveWriter};
 pub use archive_path::ArchivePath;
@@ -42,6 +44,7 @@ pub use central_dir::CentralDirectoryHeader;
 #[cfg(feature = "compact")]
 pub use compact::{CompactStats, RenameStats, compact, rename_duplicates};
 pub use dos_time::DosDateTime;
+pub use entry_kind::EntryKind;
 pub use error::BaleError;
 pub use local_file::LocalFileHeader;
 pub use mmap::{MappedArchive, MappedArchiveMut};


### PR DESCRIPTION
## Summary

- Add type-safe entry access with `file()`, `folder()`, `symlink()`, and `entry()` methods on `ArchiveRead` trait
- Return typed wrappers (`FileEntry`, `DirEntry`, `SymlinkEntry`) or `Entry` enum for generic access
- New `ArchiveWrite` methods: `add_folder()` and `add_symlink()` for creating directory and symlink entries
- `EntryKind` enum classifies entries by Unix mode (S_IFREG, S_IFDIR, S_IFLNK)
- `CentralDirectoryHeader.kind()` extracts entry type from external_attrs
- Compact now creates missing explicit directory entries for implicit directories

## Test plan

- [x] All existing tests pass (180 tests)
- [x] Clippy passes with no warnings
- [x] Pre-commit hooks pass

Closes #45