### PR TITLE
Remove ZERO_PAD static buffer

### DIFF
--- a/src/archive/writer.rs
+++ b/src/archive/writer.rs
@@ -12,12 +12,6 @@ use std::io::Read;
 use std::path::Path;
 use zerocopy::IntoBytes;
 
-/// Pre-allocated zero buffer for padding (avoids allocation for common cases).
-///
-/// Sized to match the default alignment (4096 bytes). For larger alignments,
-/// padding is written in chunks from this buffer.
-static ZERO_PAD: [u8; 4096] = [0u8; 4096];
-
 impl Archive<MappedArchiveMut> {
     /// Creates a new empty archive at the given path.
     ///
@@ -546,11 +540,8 @@ impl ArchiveWrite for Archive<MappedArchiveMut> {
         self.mmap.extend(extra.as_bytes())?;
         self.mmap.extend(data)?;
 
-        let mut remaining = padding;
-        while remaining > 0 {
-            let chunk = remaining.min(ZERO_PAD.len());
-            self.mmap.extend(&ZERO_PAD[..chunk])?;
-            remaining -= chunk;
+        if padding > 0 {
+            self.mmap.set_len(self.mmap.len() + padding)?;
         }
 
         self.write_offset += aligned_size;

--- a/src/fuse/inode.rs
+++ b/src/fuse/inode.rs
@@ -1,0 +1,26 @@
+//! Inode allocation constants for the FUSE filesystem.
+
+use std::time::Duration;
+
+/// Root directory inode number.
+///
+/// Per FUSE convention, the root directory is always inode 1.
+pub const ROOT_INO: u64 = 1;
+
+/// Starting inode number for regular files.
+///
+/// Files are allocated inodes starting at 0x1_0000_0000 to separate
+/// them from directory inodes in the inode space.
+pub const FILE_INO_START: u64 = 0x1_0000_0000;
+
+/// Starting inode number for directories.
+///
+/// Directories are allocated inodes starting at 0x2_0000_0000 to separate
+/// them from file inodes in the inode space.
+pub const DIR_INO_START: u64 = 0x2_0000_0000;
+
+/// Time-to-live for cached attributes and entries.
+///
+/// FUSE caches file attributes and directory entries for this duration
+/// before re-querying the filesystem.
+pub const TTL: Duration = Duration::from_secs(1);


### PR DESCRIPTION
## Summary

- Remove 4096-byte `ZERO_PAD` static buffer from writer
- Replace chunked zero-padding loop with single `set_len()` call
- `MappedArchiveMut::set_len()` already extends with zeros using `fill(0)`

## Test plan

- [x] All tests pass
- [x] Pre-commit hooks pass

Closes #44