### PR TITLE
Create FUSE module structure

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -170,13 +170,15 @@ Expected output goes in matching `.stdout` files.
 
 ## Format Specification
 
-| Property   | Value                             |
-| ---------- | --------------------------------- |
-| EOCD       | Standard 22-byte zip format       |
-| Stride     | `header_size + path_size` (fixed) |
-| Byte order | Little-endian                     |
-| Alignment  | 4096 bytes (configurable, 2^N)    |
-| Max path   | 256 bytes (configurable, 1-2048)  |
+| Property   | Value                                        |
+| ---------- | -------------------------------------------- |
+| Version    | 0.2.0                                        |
+| EOCD       | Standard 22-byte zip format                  |
+| CD Stride  | `46 + path_size + 8` (header + path + extra) |
+| LFH Stride | `30 + path_size + 8` (header + path + extra) |
+| Byte order | Little-endian                                |
+| Alignment  | 4096 bytes (configurable, 2^N)               |
+| Max path   | 256 bytes (configurable, 1-2048)             |
 
 ### Archive Layout
 
@@ -201,12 +203,28 @@ Expected output goes in matching `.stdout` files.
 | Offset | Size | Field                                   |
 | ------ | ---- | --------------------------------------- |
 | 0      | 4    | Magic signature "BALE" (0x454C4142 LE)  |
-| 4      | 1    | Major version                           |
-| 5      | 1    | Minor version                           |
-| 6      | 1    | Patch version                           |
+| 4      | 1    | Major version (0)                       |
+| 5      | 1    | Minor version (2)                       |
+| 6      | 1    | Patch version (0)                       |
 | 7      | 1    | Alignment power (2^N, e.g., 12 = 4096)  |
 | 8      | 2    | Path size (1-2048, little-endian)       |
-| 10     | 148  | Reserved (zeros)                        |
+| 10     | 4    | Next ID (u32, for stable entry IDs)     |
+| 14     | 144  | Reserved (zeros)                        |
+
+### Entry IDs and Extra Fields
+
+Each entry has a stable u32 ID stored in a ZIP-compatible extra field:
+
+| Offset | Size | Field                                   |
+| ------ | ---- | --------------------------------------- |
+| 0      | 2    | Tag (0xBA1D = "BAID" with 1 as I)       |
+| 2      | 2    | Size (always 4)                         |
+| 4      | 4    | Entry ID (u32, little-endian)           |
+
+- IDs start at 1 (0 reserved for root/no-ID)
+- IDs are assigned sequentially and never reused within an archive session
+- Compact operation renumbers entries 1..N
+- Extra field adds 8 bytes to CD and local file header stride
 
 ### ZIP64 Compatibility
 

--- a/src/fuse/dir_entry.rs
+++ b/src/fuse/dir_entry.rs
@@ -1,0 +1,47 @@
+//! Directory entry for FUSE filesystem.
+
+use fuser::FileType;
+
+/// A directory entry for FUSE readdir operations.
+///
+/// This struct represents a single entry in a directory listing,
+/// containing the entry name, inode number, and file type.
+#[derive(Debug, Clone)]
+pub struct FuseDirEntry {
+    /// The entry name (file or directory name, not full path).
+    pub name: String,
+    /// The inode number for this entry.
+    pub ino: u64,
+    /// The file type (regular file, directory, symlink, etc.).
+    pub kind: FileType,
+}
+
+impl FuseDirEntry {
+    /// Creates a new directory entry.
+    #[must_use]
+    pub fn new(name: impl Into<String>, ino: u64, kind: FileType) -> Self {
+        Self {
+            name: name.into(),
+            ino,
+            kind,
+        }
+    }
+
+    /// Creates a directory entry for a regular file.
+    #[must_use]
+    pub fn file(name: impl Into<String>, ino: u64) -> Self {
+        Self::new(name, ino, FileType::RegularFile)
+    }
+
+    /// Creates a directory entry for a directory.
+    #[must_use]
+    pub fn directory(name: impl Into<String>, ino: u64) -> Self {
+        Self::new(name, ino, FileType::Directory)
+    }
+
+    /// Creates a directory entry for a symbolic link.
+    #[must_use]
+    pub fn symlink(name: impl Into<String>, ino: u64) -> Self {
+        Self::new(name, ino, FileType::Symlink)
+    }
+}

--- a/src/fuse/mod.rs
+++ b/src/fuse/mod.rs
@@ -1,0 +1,10 @@
+//! FUSE filesystem support for bale archives.
+//!
+//! This module provides types and constants for mounting bale archives
+//! as read-only FUSE filesystems.
+
+mod dir_entry;
+mod inode;
+
+pub use dir_entry::FuseDirEntry;
+pub use inode::{DIR_INO_START, FILE_INO_START, ROOT_INO, TTL};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,6 +26,9 @@ mod dos_time;
 mod entry_kind;
 /// Error types for bale operations.
 mod error;
+/// FUSE filesystem support.
+#[cfg(feature = "fuse")]
+pub mod fuse;
 /// Local File Header for ZIP entries.
 mod local_file;
 /// Memory-mapped file access.


### PR DESCRIPTION
## Summary

- Add `src/fuse/mod.rs` with module exports and re-exports
- Add `src/fuse/dir_entry.rs` with `FuseDirEntry` struct for FUSE readdir operations
- Add `src/fuse/inode.rs` with inode constants (`ROOT_INO`, `FILE_INO_START`, `DIR_INO_START`, `TTL`)
- Add `#[cfg(feature = "fuse")] pub mod fuse` to lib.rs
- Update CLAUDE.md with format v0.2.0 and entry ID documentation

## Test plan

- [x] Module compiles with `--features fuse`
- [x] Types are exported from `bale::fuse`
- [x] All tests pass
- [x] Pre-commit hooks pass

Closes #37