### PR TITLE
Clear modified_data after sync

### DIFF
--- a/src/fuse/bale_fs_state.rs
+++ b/src/fuse/bale_fs_state.rs
@@ -294,6 +294,7 @@ impl BaleFsState {
         }
 
         self.archive.sync().map_err(|_| libc::EIO)?;
+        self.modified_data.clear();
         Ok(())
     }
 
@@ -785,6 +786,28 @@ mod tests {
             state.get_parent_inode(abc_ino),
             ab_ino,
             "a/b/c's parent should be a/b"
+        );
+    }
+
+    /// Tests that `modified_data` is cleared after sync.
+    #[test]
+    fn modified_data_cleared_after_sync() {
+        let archive = create_test_archive(&[("test.txt", b"original", 0o100644)]);
+        let mut state = BaleFsState::new(archive, false, 1000, 1000);
+
+        // Modify the file.
+        state
+            .modified_data
+            .insert("test.txt".to_string(), b"modified".to_vec());
+        assert!(!state.modified_data.is_empty());
+
+        // Sync to archive.
+        state.sync_modified_to_archive().unwrap();
+
+        // modified_data should be cleared.
+        assert!(
+            state.modified_data.is_empty(),
+            "modified_data should be cleared after sync"
         );
     }
 }


### PR DESCRIPTION
## Summary
- Added `self.modified_data.clear()` after successful sync to free memory
- Data is already persisted to archive, no need to keep it in memory

## Test plan
- [x] Added `modified_data_cleared_after_sync` test that verifies modified_data is empty after sync
- [x] All 194 tests pass

Fixes #72