### PR TITLE
Update FSName to include archive filename

### DIFF
--- a/src/fuse/bale_fs.rs
+++ b/src/fuse/bale_fs.rs
@@ -23,6 +23,8 @@ use crate::{ArchiveRead, ArchiveWriter, BaleError, DosDateTime, EntryKind};
 pub struct BaleFs {
     /// Mutable filesystem state protected by a mutex.
     state: Mutex<BaleFsState>,
+    /// Archive filename for FSName mount option.
+    archive_name: String,
 }
 
 impl BaleFs {
@@ -39,6 +41,12 @@ impl BaleFs {
     ///
     /// Returns an error if the archive cannot be opened.
     pub fn new(path: impl AsRef<Path>, read_only: bool) -> Result<Self, BaleError> {
+        let archive_name = path
+            .as_ref()
+            .file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or("archive")
+            .to_string();
         let archive = ArchiveWriter::open(path)?;
         let uid = {
             #[cfg(unix)]
@@ -65,6 +73,7 @@ impl BaleFs {
 
         Ok(Self {
             state: Mutex::new(state),
+            archive_name,
         })
     }
 
@@ -93,7 +102,7 @@ impl BaleFs {
         let read_only = self.state.lock().map_or(true, |s| s.read_only);
 
         let mut options = vec![
-            MountOption::FSName("bale".to_string()),
+            MountOption::FSName(format!("bale:{}", self.archive_name)),
             MountOption::DefaultPermissions,
         ];
 


### PR DESCRIPTION
## Summary
- Added `archive_name` field to `BaleFs` struct
- Extract filename from archive path during construction
- FSName now shows `bale:<filename>` instead of just `bale`

## Example
When mounting `mydata.bale`, `mount` output will show:
```
bale:mydata.bale on /mnt type fuse (...)
```

## Test plan
- [x] All 193 tests pass

Fixes #74