### PR TITLE
Fix lookup error code for invalid UTF-8

### DIFF
--- a/src/fuse/bale_fs.rs
+++ b/src/fuse/bale_fs.rs
@@ -130,7 +130,7 @@ impl fuser::Filesystem for BaleFs {
         let name_str = match name.to_str() {
             Some(s) => s,
             None => {
-                reply.error(libc::ENOENT);
+                reply.error(libc::EINVAL);
                 return;
             }
         };


### PR DESCRIPTION
## Summary
- Changed error code from `ENOENT` to `EINVAL` when lookup receives invalid UTF-8 filename

## Rationale
When a filename contains invalid UTF-8 bytes, the input itself is malformed. `EINVAL` (invalid argument) better describes this condition than `ENOENT` (file not found).

## Test plan
- [x] All 193 tests pass

Fixes #75