### PR TITLE
Use nix Mode and SFlag types for file mode handling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ reader = []
 writer = []
 compact = ["reader", "writer"]
 cli = ["reader", "writer", "dep:clap", "dep:env_logger"]
-fuse = ["cli", "dep:fuser", "dep:nix"]
+fuse = ["cli", "dep:fuser"]
 bin = ["compact", "fuse"]
 
 [dependencies]
@@ -25,6 +25,7 @@ thiserror = "2.0.17"
 chrono = "0.4.42"
 tempfile = "3.24.0"
 safename = { version = "0.1.0", features = ["medium"] }
+nix = { version = "0.30.1", default-features = false, features = ["fs", "user"] }
 
 # Logging
 log = "0.4.29"
@@ -43,7 +44,6 @@ clap = { version = "4", features = ["derive"], optional = true }
 
 # FUSE (optional)
 fuser = { version = "0.16.0", optional = true }
-nix = { version = "0.30.1", optional = true, default-features = false, features = ["user"] }
 
 [build-dependencies]
 chrono = "0.4.42"

--- a/src/archive/writer.rs
+++ b/src/archive/writer.rs
@@ -6,11 +6,17 @@ use crate::{
     ArchivePath, BaleEocd, BaleError, CentralDirectoryHeader, DosDateTime, EntryKind, Eocd,
     LocalFileHeader, MappedArchiveMut, Trailer, Zip64Eocd,
 };
+use nix::sys::stat::SFlag;
 use std::collections::HashSet;
 use std::fs::File;
 use std::io::Read;
 use std::path::Path;
 use zerocopy::IntoBytes;
+
+/// Default permission bits for regular files (rw-r--r--).
+/// Used on non-Unix platforms where file permissions aren't available.
+#[cfg_attr(unix, allow(dead_code))]
+const DEFAULT_FILE_PERM: u32 = 0o644;
 
 impl Archive<MappedArchiveMut> {
     /// Creates a new empty archive at the given path.
@@ -581,7 +587,7 @@ impl ArchiveWrite for Archive<MappedArchiveMut> {
             }
             #[cfg(not(unix))]
             {
-                0o644
+                SFlag::S_IFREG.bits() | DEFAULT_FILE_PERM
             }
         };
 
@@ -663,10 +669,9 @@ impl ArchiveWrite for Archive<MappedArchiveMut> {
         let path_str = path.as_ref();
 
         // Ensure directory mode bits are set.
-        const S_IFDIR: u32 = 0o040000;
-        let mode = if mode & 0o170000 == 0 {
+        let mode = if mode & SFlag::S_IFMT.bits() == 0 {
             // No file type bits set, add directory bits.
-            mode | S_IFDIR
+            mode | SFlag::S_IFDIR.bits()
         } else {
             mode
         };
@@ -691,10 +696,9 @@ impl ArchiveWrite for Archive<MappedArchiveMut> {
         let target_str = target.as_ref();
 
         // Ensure symlink mode bits are set.
-        const S_IFLNK: u32 = 0o120000;
-        let mode = if mode & 0o170000 == 0 {
+        let mode = if mode & SFlag::S_IFMT.bits() == 0 {
             // No file type bits set, add symlink bits.
-            mode | S_IFLNK
+            mode | SFlag::S_IFLNK.bits()
         } else {
             mode
         };

--- a/src/bin/bale/commands/list.rs
+++ b/src/bin/bale/commands/list.rs
@@ -3,6 +3,7 @@
 use std::path::Path;
 
 use bale::{ArchivePath, ArchiveRead, ArchiveReader, DosDateTime};
+use nix::sys::stat::{Mode, SFlag};
 
 use crate::error::BaleCliError;
 
@@ -10,6 +11,9 @@ use crate::error::BaleCliError;
 const MONTHS: [&str; 12] = [
     "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec",
 ];
+
+/// Executable permission mask (any of user/group/other execute).
+const EXEC_MASK: u32 = Mode::S_IXUSR.bits() | Mode::S_IXGRP.bits() | Mode::S_IXOTH.bits();
 
 /// Lists entries in an archive with ls -alF style output.
 ///
@@ -40,23 +44,59 @@ pub fn run(archive_path: impl AsRef<Path>) -> Result<(), BaleCliError> {
 
 /// Formats Unix mode bits as a permission string (e.g., `-rw-r--r--`).
 fn format_permissions(mode: u32) -> String {
-    let file_type = match mode & 0o170000 {
-        0o040000 => 'd', // Directory
-        0o120000 => 'l', // Symlink
-        0o100000 => '-', // Regular file
-        _ => '-',        // Default to regular file
+    let file_type = match mode & SFlag::S_IFMT.bits() {
+        x if x == SFlag::S_IFDIR.bits() => 'd',
+        x if x == SFlag::S_IFLNK.bits() => 'l',
+        x if x == SFlag::S_IFREG.bits() => '-',
+        _ => '-', // Default to regular file
     };
 
     let perms = [
-        if mode & 0o400 != 0 { 'r' } else { '-' },
-        if mode & 0o200 != 0 { 'w' } else { '-' },
-        if mode & 0o100 != 0 { 'x' } else { '-' },
-        if mode & 0o040 != 0 { 'r' } else { '-' },
-        if mode & 0o020 != 0 { 'w' } else { '-' },
-        if mode & 0o010 != 0 { 'x' } else { '-' },
-        if mode & 0o004 != 0 { 'r' } else { '-' },
-        if mode & 0o002 != 0 { 'w' } else { '-' },
-        if mode & 0o001 != 0 { 'x' } else { '-' },
+        if mode & Mode::S_IRUSR.bits() != 0 {
+            'r'
+        } else {
+            '-'
+        },
+        if mode & Mode::S_IWUSR.bits() != 0 {
+            'w'
+        } else {
+            '-'
+        },
+        if mode & Mode::S_IXUSR.bits() != 0 {
+            'x'
+        } else {
+            '-'
+        },
+        if mode & Mode::S_IRGRP.bits() != 0 {
+            'r'
+        } else {
+            '-'
+        },
+        if mode & Mode::S_IWGRP.bits() != 0 {
+            'w'
+        } else {
+            '-'
+        },
+        if mode & Mode::S_IXGRP.bits() != 0 {
+            'x'
+        } else {
+            '-'
+        },
+        if mode & Mode::S_IROTH.bits() != 0 {
+            'r'
+        } else {
+            '-'
+        },
+        if mode & Mode::S_IWOTH.bits() != 0 {
+            'w'
+        } else {
+            '-'
+        },
+        if mode & Mode::S_IXOTH.bits() != 0 {
+            'x'
+        } else {
+            '-'
+        },
     ];
 
     format!(
@@ -92,7 +132,7 @@ fn format_date_time(mtime: &DosDateTime) -> String {
 /// - `@` for symlinks
 /// - empty for regular files
 fn get_type_indicator(mode: u32, path: &str) -> &'static str {
-    let file_type = mode & 0o170000;
+    let file_type = mode & SFlag::S_IFMT.bits();
 
     // Don't add indicator if path already has a trailing slash.
     if path.ends_with('/') {
@@ -100,10 +140,10 @@ fn get_type_indicator(mode: u32, path: &str) -> &'static str {
     }
 
     match file_type {
-        0o040000 => "/",               // Directory
-        0o120000 => "@",               // Symlink
-        _ if mode & 0o111 != 0 => "*", // Executable
-        _ => "",                       // Regular file
+        x if x == SFlag::S_IFDIR.bits() => "/",
+        x if x == SFlag::S_IFLNK.bits() => "@",
+        _ if mode & EXEC_MASK != 0 => "*", // Executable
+        _ => "",                           // Regular file
     }
 }
 

--- a/src/compact.rs
+++ b/src/compact.rs
@@ -3,9 +3,13 @@
 use crate::{
     ArchivePath, ArchiveRead, ArchiveReader, ArchiveWrite, ArchiveWriter, BaleError, EntryKind,
 };
+use nix::sys::stat::SFlag;
 use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::path::{Path, PathBuf};
+
+/// Default permission bits for directories (rwxr-xr-x).
+const DEFAULT_DIR_PERM: u32 = 0o755;
 
 /// Guard that deletes a temp file on drop unless marked to persist.
 struct TempFileGuard {
@@ -166,7 +170,7 @@ pub fn compact(path: impl AsRef<Path>) -> Result<CompactStats, BaleError> {
         for dir_bytes in &missing_dirs_sorted {
             let dir_str = std::str::from_utf8(dir_bytes)?;
             // Use default directory mode (rwxr-xr-x).
-            writer.add_folder(dir_str, 0o755)?;
+            writer.add_folder(dir_str, SFlag::S_IFDIR.bits() | DEFAULT_DIR_PERM)?;
         }
 
         for (header, path_bytes) in &final_entries {

--- a/src/entry_kind.rs
+++ b/src/entry_kind.rs
@@ -1,5 +1,7 @@
 //! Entry type classification based on Unix mode bits.
 
+use nix::sys::stat::SFlag;
+
 /// Entry type based on Unix mode bits in external_attrs.
 ///
 /// ZIP archives store Unix file type and permissions in the upper 16 bits
@@ -19,28 +21,16 @@ pub enum EntryKind {
 }
 
 impl EntryKind {
-    /// Unix file type mask (S_IFMT).
-    const S_IFMT: u32 = 0o170000;
-
-    /// Regular file (S_IFREG).
-    const S_IFREG: u32 = 0o100000;
-
-    /// Directory (S_IFDIR).
-    const S_IFDIR: u32 = 0o040000;
-
-    /// Symbolic link (S_IFLNK).
-    const S_IFLNK: u32 = 0o120000;
-
     /// Determines entry kind from Unix mode bits.
     ///
     /// Extracts the file type from the mode and returns the corresponding
     /// `EntryKind`. Unrecognized types are returned as `Other`.
     #[must_use]
     pub fn from_mode(mode: u32) -> Self {
-        match mode & Self::S_IFMT {
-            Self::S_IFREG => Self::File,
-            Self::S_IFDIR => Self::Directory,
-            Self::S_IFLNK => Self::Symlink,
+        match mode & SFlag::S_IFMT.bits() {
+            x if x == SFlag::S_IFREG.bits() => Self::File,
+            x if x == SFlag::S_IFDIR.bits() => Self::Directory,
+            x if x == SFlag::S_IFLNK.bits() => Self::Symlink,
             // Mode 0 (no type bits) defaults to File for compatibility.
             // Many ZIP tools don't set type bits for regular files.
             0 => Self::File,

--- a/src/fuse/bale_fs.rs
+++ b/src/fuse/bale_fs.rs
@@ -11,8 +11,9 @@ use fuser::{
 };
 
 use nix::libc;
+use nix::sys::stat::Mode;
 
-use crate::fuse::bale_fs_state::BaleFsState;
+use crate::fuse::bale_fs_state::{BaleFsState, DEFAULT_FILE_PERM, PERM_MASK};
 use crate::fuse::{ROOT_INO, TTL};
 use crate::{ArchiveRead, ArchiveWriter, BaleError, DosDateTime, EntryKind};
 
@@ -484,7 +485,7 @@ impl fuser::Filesystem for BaleFs {
             .unwrap_or(state.mount_time);
 
         let mode = state.get_file_mode(&path);
-        let perm = (mode & 0o777) as u16;
+        let perm = (mode & PERM_MASK) as u16;
 
         let attr = fuser::FileAttr {
             ino,
@@ -495,7 +496,11 @@ impl fuser::Filesystem for BaleFs {
             ctime: mtime,
             crtime: mtime,
             kind: FileType::RegularFile,
-            perm: if perm == 0 { 0o644 } else { perm },
+            perm: if perm == 0 {
+                DEFAULT_FILE_PERM as u16
+            } else {
+                perm
+            },
             nlink: 1,
             uid: state.uid,
             gid: state.gid,
@@ -538,6 +543,7 @@ impl fuser::Filesystem for BaleFs {
             }
         };
 
+        let mode = Mode::from_bits_truncate(mode);
         match state.create_directory(parent, name, mode) {
             Ok((ino, attr)) => reply.entry(&TTL, &attr, ino),
             Err(e) => reply.error(e),
@@ -605,6 +611,7 @@ impl fuser::Filesystem for BaleFs {
             }
         };
 
+        let mode = Mode::from_bits_truncate(mode);
         match state.create_file(parent, name, mode) {
             Ok((ino, attr)) => {
                 // Use inode as file handle for simplicity.

--- a/src/fuse/bale_fs_state.rs
+++ b/src/fuse/bale_fs_state.rs
@@ -5,11 +5,27 @@ use std::time::SystemTime;
 
 use fuser::FileType;
 use nix::libc;
+use nix::sys::stat::{Mode, SFlag};
 
 use crate::fuse::{DIR_INO_START, FILE_INO_START, FuseDirEntry, ROOT_INO};
 use crate::{
     ArchiveRead, ArchiveWrite, ArchiveWriter, CentralDirectoryHeader, DosDateTime, EntryKind,
 };
+
+/// Default permission bits for regular files (rw-r--r--).
+pub(super) const DEFAULT_FILE_PERM: u32 = 0o644;
+
+/// Default permission bits for directories (rwxr-xr-x).
+pub(super) const DEFAULT_DIR_PERM: u32 = 0o755;
+
+/// Bitmask to extract permission bits from a mode value.
+pub(super) const PERM_MASK: u32 = 0o777;
+
+/// Default file mode: regular file with default permissions.
+const DEFAULT_FILE_MODE: u32 = SFlag::S_IFREG.bits() | DEFAULT_FILE_PERM;
+
+/// Default directory mode: directory with default permissions.
+const DEFAULT_DIR_MODE: u32 = SFlag::S_IFDIR.bits() | DEFAULT_DIR_PERM;
 
 /// Internal state for the BaleFs filesystem.
 pub(super) struct BaleFsState {
@@ -208,9 +224,9 @@ impl BaleFsState {
             crtime: self.mount_time,
             kind,
             perm: if kind == FileType::Directory {
-                0o755
+                DEFAULT_DIR_PERM as u16
             } else {
-                0o644
+                DEFAULT_FILE_PERM as u16
             },
             nlink: 1,
             uid: self.uid,
@@ -229,7 +245,7 @@ impl BaleFsState {
         header: &CentralDirectoryHeader,
     ) -> fuser::FileAttr {
         let mode = header.external_attrs.get() >> 16;
-        let perm = (mode & 0o777) as u16;
+        let perm = (mode & PERM_MASK) as u16;
         let size = header.uncompressed_size.get() as u64;
         let mtime = DosDateTime::from_date_time_parts(header.mod_date.get(), header.mod_time.get())
             .to_system_time_or_epoch();
@@ -243,7 +259,11 @@ impl BaleFsState {
             ctime: mtime,
             crtime: mtime,
             kind,
-            perm: if perm == 0 { 0o644 } else { perm },
+            perm: if perm == 0 {
+                DEFAULT_FILE_PERM as u16
+            } else {
+                perm
+            },
             nlink: 1,
             uid: self.uid,
             gid: self.gid,
@@ -275,9 +295,9 @@ impl BaleFsState {
             .find_entry_with_path(path)
             .map(|(header, _, _)| {
                 let mode = header.external_attrs.get() >> 16;
-                if mode == 0 { 0o644 } else { mode }
+                if mode == 0 { DEFAULT_FILE_MODE } else { mode }
             })
-            .unwrap_or(0o644)
+            .unwrap_or(DEFAULT_FILE_MODE)
     }
 
     /// Syncs all modified files to the archive.
@@ -305,7 +325,7 @@ impl BaleFsState {
         &mut self,
         parent_ino: u64,
         name: &str,
-        mode: u32,
+        mode: Mode,
     ) -> Result<(u64, fuser::FileAttr), i32> {
         // Check parent exists.
         if !self.dir_contents.contains_key(&parent_ino) {
@@ -345,9 +365,9 @@ impl BaleFsState {
 
         // Add directory entry to archive (path ending with /).
         let dir_path = format!("{}/", full_path);
-        let mode = 0o40000 | (mode & 0o7777); // directory bit + permission bits
+        let archive_mode = SFlag::S_IFDIR.bits() | mode.bits();
         self.archive
-            .add_entry(&dir_path, &[], mode)
+            .add_entry(&dir_path, &[], archive_mode)
             .map_err(|_| libc::EIO)?;
 
         let attr = self.get_attr(ino, FileType::Directory);
@@ -449,7 +469,7 @@ impl BaleFsState {
         &mut self,
         parent_ino: u64,
         name: &str,
-        mode: u32,
+        mode: Mode,
     ) -> Result<(u64, fuser::FileAttr), i32> {
         // Check parent exists.
         if !self.dir_contents.contains_key(&parent_ino) {
@@ -491,12 +511,12 @@ impl BaleFsState {
         self.modified_data.insert(full_path.clone(), Vec::new());
 
         // Add empty file to archive.
-        let file_mode = 0o100000 | (mode & 0o777); // regular file + permissions
+        let archive_mode = SFlag::S_IFREG.bits() | mode.bits();
         self.archive
-            .add_entry(&full_path, &[], file_mode)
+            .add_entry(&full_path, &[], archive_mode)
             .map_err(|_| libc::EIO)?;
 
-        let perm = (mode & 0o777) as u16;
+        let perm = mode.bits() as u16;
         let attr = fuser::FileAttr {
             ino,
             size: 0,
@@ -506,7 +526,11 @@ impl BaleFsState {
             ctime: self.mount_time,
             crtime: self.mount_time,
             kind: FileType::RegularFile,
-            perm: if perm == 0 { 0o644 } else { perm },
+            perm: if perm == 0 {
+                DEFAULT_FILE_PERM as u16
+            } else {
+                perm
+            },
             nlink: 1,
             uid: self.uid,
             gid: self.gid,
@@ -651,8 +675,7 @@ impl BaleFsState {
                 let mode = self.get_file_mode(&old_path);
                 let _ = self.archive.add_entry(&new_path, &data, mode);
             } else if let Some(data) = self.modified_data.get(&new_path) {
-                let mode = 0o100644;
-                let _ = self.archive.add_entry(&new_path, data, mode);
+                let _ = self.archive.add_entry(&new_path, data, DEFAULT_FILE_MODE);
             }
             let _ = self.archive.delete(&old_path);
         } else {
@@ -714,7 +737,7 @@ impl BaleFsState {
             // Update archive: add new dir entry, remove old.
             let old_dir_path = format!("{}/", old_path);
             let new_dir_path = format!("{}/", new_path);
-            let _ = self.archive.add_entry(&new_dir_path, &[], 0o40755);
+            let _ = self.archive.add_entry(&new_dir_path, &[], DEFAULT_DIR_MODE);
             let _ = self.archive.delete(&old_dir_path);
         }
 
@@ -797,7 +820,7 @@ mod tests {
         let mut state = BaleFsState::new(archive, false, 1000, 1000);
 
         // Create directory with mode 0o700 (rwx------).
-        let result = state.create_directory(ROOT_INO, "private", 0o700);
+        let result = state.create_directory(ROOT_INO, "private", Mode::S_IRWXU);
         assert!(result.is_ok());
 
         // Sync to persist the entry.


### PR DESCRIPTION
## Summary

- Move nix from fuse-feature-gated to core dependency
- Use `nix::sys::stat::SFlag` for file type detection (S_IFMT, S_IFREG, S_IFDIR, S_IFLNK)
- Use `nix::sys::stat::Mode` for permission bits (S_IRUSR, S_IWUSR, etc.)
- Add named constants for default permissions (`DEFAULT_FILE_PERM`, `DEFAULT_DIR_PERM`, `PERM_MASK`)
- Replace magic octal numbers with typed constants throughout the codebase

Files updated:
- `Cargo.toml`: Move nix to core dependencies
- `entry_kind.rs`: Use SFlag for file type detection
- `writer.rs`: Use SFlag for directory/symlink type bits
- `list.rs`: Use SFlag and Mode for permission display
- `compact.rs`: Use SFlag for directory mode
- `fuse/bale_fs*.rs`: Use Mode for create operations

Closes #82

## Test plan

- [x] All 195 tests pass
- [x] Clippy passes with no warnings
- [x] Code formatted with cargo fmt