### PR TITLE
Reserve .bale* paths for future format extensions

### DIFF
--- a/src/archive_path.rs
+++ b/src/archive_path.rs
@@ -7,6 +7,13 @@ use std::path::{Path, PathBuf};
 
 use crate::BaleError;
 
+/// Reserved path prefix for bale internal use.
+///
+/// Paths with components starting with this prefix are rejected to reserve
+/// space for future format extensions (e.g., virtual `.bale/` metadata folder
+/// in FUSE mounts).
+const RESERVED_PREFIX: &str = ".bale";
+
 /// A path within a bale archive, either borrowed or owned.
 ///
 /// Archive paths use forward slashes as separators and are typically UTF-8,
@@ -285,22 +292,37 @@ impl<'a> ArchivePath<'a> {
             return Err(BaleError::InvalidPath);
         }
 
-        // Validate each component against safename rules.
+        // Validate each component against safename rules and reserved prefixes.
         for component in &components {
             safename::validate_file(component)?;
+            Self::check_reserved(component)?;
         }
 
         Ok(Cow::Owned(components.join("/").into_bytes()))
     }
 
-    /// Validates a normalized path against safename rules.
+    /// Validates a normalized path against safename rules and reserved prefixes.
     ///
     /// # Errors
     ///
     /// Returns `BaleError::UnsafeFilename` if any component violates safename rules.
+    /// Returns `BaleError::ReservedPath` if any component starts with `.bale`.
     fn validate_safename(path: &str) -> Result<(), BaleError> {
         for component in path.split('/') {
             safename::validate_file(component)?;
+            Self::check_reserved(component)?;
+        }
+        Ok(())
+    }
+
+    /// Checks if a path component uses the reserved `.bale` prefix.
+    ///
+    /// # Errors
+    ///
+    /// Returns `BaleError::ReservedPath` if the component starts with `.bale`.
+    fn check_reserved(component: &str) -> Result<(), BaleError> {
+        if component.starts_with(RESERVED_PREFIX) {
+            return Err(BaleError::ReservedPath(component.to_string()));
         }
         Ok(())
     }
@@ -849,6 +871,48 @@ mod tests {
         assert!(ArchivePath::try_from("file_with_underscores").is_ok());
         assert!(ArchivePath::try_from("CamelCase.TXT").is_ok());
         assert!(ArchivePath::try_from("123numeric").is_ok());
+    }
+
+    // ==================== Reserved Path Tests ====================
+
+    /// Paths starting with .bale are rejected.
+    #[test]
+    fn reserved_bale_prefix_rejected() {
+        // Exact match
+        assert!(ArchivePath::try_from(".bale").is_err());
+        // With extension
+        assert!(ArchivePath::try_from(".bale.txt").is_err());
+        // As directory
+        assert!(ArchivePath::try_from(".bale/file.txt").is_err());
+        // Nested
+        assert!(ArchivePath::try_from("foo/.bale").is_err());
+        assert!(ArchivePath::try_from("foo/.bale/bar").is_err());
+        // With suffix
+        assert!(ArchivePath::try_from(".balesomething").is_err());
+        assert!(ArchivePath::try_from("dir/.baledata").is_err());
+    }
+
+    /// Similar but non-reserved paths are accepted.
+    #[test]
+    fn similar_to_reserved_accepted() {
+        // .bal (not .bale)
+        assert!(ArchivePath::try_from(".bal").is_ok());
+        // bale without dot
+        assert!(ArchivePath::try_from("bale").is_ok());
+        assert!(ArchivePath::try_from("bale.txt").is_ok());
+        // Contains .bale but doesn't start with it
+        assert!(ArchivePath::try_from("foo.bale").is_ok());
+        assert!(ArchivePath::try_from("mybale").is_ok());
+    }
+
+    /// Reserved path check returns correct error type.
+    #[test]
+    fn reserved_path_error_type() {
+        let result = ArchivePath::try_from(".bale");
+        assert!(matches!(result, Err(BaleError::ReservedPath(_))));
+        if let Err(BaleError::ReservedPath(path)) = result {
+            assert_eq!(path, ".bale");
+        }
     }
 
     // ==================== Property Tests ====================

--- a/src/bin/bale/commands/check.rs
+++ b/src/bin/bale/commands/check.rs
@@ -20,6 +20,7 @@ enum ArchiveStatus {
 /// Verifies:
 /// - Format validity (via `ArchiveReader::open`)
 /// - CRC-32 checksums
+/// - Path validity (UTF-8, safename rules, reserved prefixes)
 /// - Central Directory ordering (sorted by path)
 /// - Duplicate path detection
 /// - Orphaned data detection
@@ -35,10 +36,17 @@ pub fn run(archive_path: impl AsRef<Path>, quiet: bool) -> Result<(), BaleCliErr
     let reader = ArchiveReader::open(&archive_path)?;
     let mut errors: Vec<String> = Vec::new();
 
-    // Check CRCs.
+    // Check CRCs and path validity.
     for (header, path_bytes) in reader.iter_entries() {
+        let path = ArchivePath::from_null_padded_bytes(path_bytes);
+
+        // Verify CRC.
         if let Err(e) = reader.verify_crc(header) {
-            let path = ArchivePath::from_null_padded_bytes(path_bytes);
+            errors.push(format!("'{}': {}", path, e));
+        }
+
+        // Validate path (UTF-8, safename rules, reserved prefixes).
+        if let Err(e) = path.normalize() {
             errors.push(format!("'{}': {}", path, e));
         }
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -81,4 +81,8 @@ pub enum BaleError {
     /// Size exceeds ZIP format limits.
     #[error("size overflow: {0}")]
     SizeOverflow(String),
+
+    /// Path uses reserved prefix (`.bale`).
+    #[error("reserved path: {0}")]
+    ReservedPath(String),
 }


### PR DESCRIPTION
## Summary
- Add `ReservedPath` error variant for `.bale*` path rejection
- Reject any path component starting with `.bale` during normalization
- Update `bale check` to validate paths (UTF-8, safename rules, reserved prefixes)

Closes #58

## Test plan
- [x] Unit tests for reserved path rejection
- [x] Unit tests for similar but allowed paths (`.bal`, `bale`, `foo.bale`)
- [x] Full test suite passes
- [x] Clippy clean