### PR TITLE
Add chmod support for directories in FUSE mount (#102)

### DIFF
--- a/src/fuse/bale_fs.rs
+++ b/src/fuse/bale_fs.rs
@@ -11,7 +11,7 @@ use fuser::{
 };
 
 use nix::libc;
-use nix::sys::stat::Mode;
+use nix::sys::stat::{Mode, SFlag};
 
 use crate::fuse::bale_fs_state::{BaleFsState, DEFAULT_FILE_PERM, PERM_MASK};
 use crate::fuse::{ROOT_INO, TTL};
@@ -463,8 +463,13 @@ impl fuser::Filesystem for BaleFs {
         let path = match state.inode_to_path.get(&ino) {
             Some(p) => p.clone(),
             None => {
-                // Might be a directory - just return current attrs.
+                // Might be a directory.
                 if state.dir_contents.contains_key(&ino) {
+                    // Handle directory mode change.
+                    if let Some(new_mode) = mode {
+                        let perm_bits = new_mode & PERM_MASK;
+                        state.set_dir_mode(ino, SFlag::S_IFDIR.bits() | perm_bits);
+                    }
                     let attr = state.get_attr(ino, FileType::Directory);
                     reply.attr(&TTL, &attr);
                     return;

--- a/src/fuse/bale_fs_state.rs
+++ b/src/fuse/bale_fs_state.rs
@@ -219,6 +219,12 @@ impl BaleFsState {
 
     /// Creates file attributes for a directory or generic entry.
     pub(super) fn get_attr(&self, ino: u64, kind: FileType) -> fuser::FileAttr {
+        let perm = if kind == FileType::Directory {
+            (self.get_dir_mode(ino) & PERM_MASK) as u16
+        } else {
+            DEFAULT_FILE_PERM as u16
+        };
+
         fuser::FileAttr {
             ino,
             size: 0,
@@ -228,11 +234,7 @@ impl BaleFsState {
             ctime: self.mount_time,
             crtime: self.mount_time,
             kind,
-            perm: if kind == FileType::Directory {
-                DEFAULT_DIR_PERM as u16
-            } else {
-                DEFAULT_FILE_PERM as u16
-            },
+            perm,
             nlink: 1,
             uid: self.uid,
             gid: self.gid,
@@ -311,6 +313,41 @@ impl BaleFsState {
                 if mode == 0 { DEFAULT_FILE_MODE } else { mode }
             })
             .unwrap_or(DEFAULT_FILE_MODE)
+    }
+
+    /// Gets the mode (permissions) for a directory by inode.
+    ///
+    /// Checks modified_modes first, then falls back to archive or default.
+    pub(super) fn get_dir_mode(&self, ino: u64) -> u32 {
+        let path = self.get_dir_path(ino);
+
+        // Check if mode was modified via chmod.
+        if let Some(&mode) = self.modified_modes.get(&path) {
+            return mode;
+        }
+
+        // Check archive for explicit directory entry.
+        let dir_path_with_slash = if path.is_empty() {
+            String::new()
+        } else {
+            format!("{}/", path)
+        };
+        if !dir_path_with_slash.is_empty()
+            && let Some((header, _, _)) = self.archive.find_entry_with_path(&dir_path_with_slash)
+        {
+            let mode = header.external_attrs.get() >> 16;
+            if mode != 0 {
+                return mode;
+            }
+        }
+
+        DEFAULT_DIR_MODE
+    }
+
+    /// Sets the mode (permissions) for a directory by inode.
+    pub(super) fn set_dir_mode(&mut self, ino: u64, mode: u32) {
+        let path = self.get_dir_path(ino);
+        self.modified_modes.insert(path, mode);
     }
 
     /// Syncs all modified files to the archive.


### PR DESCRIPTION
## Summary
- Add `get_dir_mode`/`set_dir_mode` methods to `BaleFsState`
- Update `get_attr` to use modified modes for directories
- Update `setattr` to handle directory chmod operations

## Test plan
- [x] All existing tests pass
- [x] `git precommit --all` passes
- [ ] Manual test: `chmod 700 /mountpoint/somedir && stat /mountpoint/somedir`

Fixes #102