### PR TITLE
Use safename for FUSE path validation and raise MAX_PATH_SIZE to 4096 (#108)

### DIFF
--- a/src/bin/bale/cli.rs
+++ b/src/bin/bale/cli.rs
@@ -31,6 +31,11 @@ pub enum Command {
     Touch {
         /// The archive to create or touch.
         path: PathBuf,
+        /// Maximum path size in bytes (1-4096, default 256).
+        ///
+        /// Only used when creating a new archive.
+        #[arg(long, default_value = "256")]
+        path_size: u16,
     },
     /// Add files to a bale archive.
     Add {
@@ -60,6 +65,7 @@ pub enum Command {
         entries: Vec<String>,
     },
     /// Delete entries from a bale archive.
+    #[command(visible_alias = "rm")]
     Delete {
         /// The archive to modify.
         archive: PathBuf,

--- a/src/bin/bale/commands/touch.rs
+++ b/src/bin/bale/commands/touch.rs
@@ -10,11 +10,11 @@ use crate::error::BaleCliError;
 
 /// Creates a bale archive or updates its modification time.
 ///
-/// If the file doesn't exist, creates a new empty bale archive.
-/// If the file exists, validates it is a valid bale archive and then
-/// updates its modification time. Returns an error if the file exists
-/// but is not a valid bale archive.
-pub fn run(path: impl AsRef<Path>) -> Result<(), BaleCliError> {
+/// If the file doesn't exist, creates a new empty bale archive with the
+/// specified path size. If the file exists, validates it is a valid bale
+/// archive and then updates its modification time (path_size is ignored).
+/// Returns an error if the file exists but is not a valid bale archive.
+pub fn run(path: impl AsRef<Path>, path_size: u16) -> Result<(), BaleCliError> {
     let path = path.as_ref();
 
     if path.exists() {
@@ -26,7 +26,7 @@ pub fn run(path: impl AsRef<Path>) -> Result<(), BaleCliError> {
         let times = FileTimes::new().set_accessed(now).set_modified(now);
         file.set_times(times)?;
     } else {
-        let mut writer = ArchiveWriter::create(path)?;
+        let mut writer = ArchiveWriter::create_with_options(path, 4096, path_size)?;
         writer.sync()?;
     }
 

--- a/src/bin/bale/main.rs
+++ b/src/bin/bale/main.rs
@@ -68,7 +68,7 @@ fn main() -> ExitCode {
 fn run(cli: Cli) -> Result<(), BaleCliError> {
     match cli.command {
         // Archive creation.
-        Command::Touch { path } => commands::touch::run(path),
+        Command::Touch { path, path_size } => commands::touch::run(path, path_size),
 
         // Content modification.
         Command::Add {

--- a/src/fuse/bale_fs.rs
+++ b/src/fuse/bale_fs.rs
@@ -153,6 +153,12 @@ impl fuser::Filesystem for BaleFs {
             }
         };
 
+        // Validate filename component using safename rules.
+        if let Err(e) = BaleFsState::validate_name(name_str) {
+            reply.error(e);
+            return;
+        }
+
         // Find parent directory contents.
         let contents = match state.dir_contents.get(&parent) {
             Some(c) => c,
@@ -874,7 +880,7 @@ impl fuser::Filesystem for BaleFs {
             file_count + dir_count, // files (inodes)
             0,                      // ffree
             4096,                   // bsize (block size)
-            256,                    // namelen (our max path component)
+            255,                    // namelen (POSIX NAME_MAX)
             0,                      // frsize (fragment size)
         );
     }

--- a/src/fuse/bale_fs_state.rs
+++ b/src/fuse/bale_fs_state.rs
@@ -97,6 +97,30 @@ impl BaleFsState {
         state
     }
 
+    /// Validates a filename component using safename rules.
+    ///
+    /// Checks length (≤255 bytes) and security rules (no control chars,
+    /// leading dashes, etc.).
+    ///
+    /// Returns `Ok(())` if valid, or `Err(errno)` on failure.
+    pub(super) fn validate_name(name: &str) -> Result<(), i32> {
+        safename::validate_file(name).map_err(|e| match e {
+            safename::SafeNameError::InvalidLength { .. } => libc::ENAMETOOLONG,
+            safename::SafeNameError::InvalidByte { .. } => libc::EINVAL,
+        })
+    }
+
+    /// Validates that a full path doesn't exceed the archive's path_size.
+    ///
+    /// Returns `Ok(())` if valid, or `Err(ENAMETOOLONG)` if too long.
+    pub(super) fn validate_path_length(&self, path: &str) -> Result<(), i32> {
+        if path.len() > self.archive.path_size() {
+            Err(libc::ENAMETOOLONG)
+        } else {
+            Ok(())
+        }
+    }
+
     /// Builds the directory tree from archive entries.
     ///
     /// Iterates through all archive entries and creates:
@@ -511,6 +535,9 @@ impl BaleFsState {
         name: &str,
         mode: Mode,
     ) -> Result<(u64, fuser::FileAttr), i32> {
+        // Check name length.
+        Self::validate_name(name)?;
+
         // Check parent exists.
         if !self.dir_contents.contains_key(&parent_ino) {
             return Err(libc::ENOENT);
@@ -523,6 +550,9 @@ impl BaleFsState {
         } else {
             format!("{}/{}", parent_path, name)
         };
+
+        // Check path length.
+        self.validate_path_length(&full_path)?;
 
         // Check directory doesn't already exist.
         if self.dir_inodes.contains_key(&full_path) {
@@ -655,6 +685,9 @@ impl BaleFsState {
         name: &str,
         mode: Mode,
     ) -> Result<(u64, fuser::FileAttr), i32> {
+        // Check name length.
+        Self::validate_name(name)?;
+
         // Check parent exists.
         if !self.dir_contents.contains_key(&parent_ino) {
             return Err(libc::ENOENT);
@@ -667,6 +700,9 @@ impl BaleFsState {
         } else {
             format!("{}/{}", parent_path, name)
         };
+
+        // Check path length.
+        self.validate_path_length(&full_path)?;
 
         // Check file doesn't already exist.
         if self.path_to_inode.contains_key(&full_path) {
@@ -778,6 +814,9 @@ impl BaleFsState {
         new_parent_ino: u64,
         new_name: &str,
     ) -> Result<(), i32> {
+        // Check new name length.
+        Self::validate_name(new_name)?;
+
         // Check both parents exist.
         if !self.dir_contents.contains_key(&old_parent_ino) {
             return Err(libc::ENOENT);
@@ -801,6 +840,9 @@ impl BaleFsState {
         } else {
             format!("{}/{}", new_parent_path, new_name)
         };
+
+        // Check new path length.
+        self.validate_path_length(&new_path)?;
 
         // Check if source is a file or directory.
         let is_file = self.path_to_inode.contains_key(&old_path);
@@ -937,6 +979,9 @@ impl BaleFsState {
         name: &str,
         target: &str,
     ) -> Result<(u64, fuser::FileAttr), i32> {
+        // Check name length.
+        Self::validate_name(name)?;
+
         // Check parent exists.
         if !self.dir_contents.contains_key(&parent_ino) {
             return Err(libc::ENOENT);
@@ -949,6 +994,9 @@ impl BaleFsState {
         } else {
             format!("{}/{}", parent_path, name)
         };
+
+        // Check path length.
+        self.validate_path_length(&full_path)?;
 
         // Check symlink doesn't already exist.
         if self.path_to_inode.contains_key(&full_path) {

--- a/src/tail/bale_eocd.rs
+++ b/src/tail/bale_eocd.rs
@@ -57,8 +57,8 @@ impl BaleEocd {
     /// Minimum allowed path size.
     pub const MIN_PATH_SIZE: u16 = 1;
 
-    /// Maximum allowed path size.
-    pub const MAX_PATH_SIZE: u16 = 2048;
+    /// Maximum allowed path size (matches POSIX PATH_MAX).
+    pub const MAX_PATH_SIZE: u16 = 4096;
 
     /// Maximum alignment power (2^24 = 16 MB).
     pub const MAX_ALIGNMENT_POW2: u8 = 24;
@@ -443,7 +443,7 @@ mod tests {
     #[test]
     fn path_size_over_max_fails_validation() {
         let mut bale = BaleEocd::new();
-        bale.path_size = U16::new(3000);
+        bale.path_size = U16::new(5000);
         assert!(!bale.is_valid());
     }
 

--- a/tests/bin/run-pjdfstest.sh
+++ b/tests/bin/run-pjdfstest.sh
@@ -6,6 +6,8 @@ set -e
 ARCHIVE="/tmp/test-pjdfstest.bale"
 TESTS_DIR="$HOME/projects/ref/pjdfstest/tests"
 OUTPUT_DIR="$HOME/projects/pjdfstest-results"
+# Use 4096 path size to match POSIX PATH_MAX for pjdfstest compliance.
+PATH_SIZE=4096
 
 # Tests that should work without permission/ownership complications.
 # These don't test chown/mkfifo/mknod/link and don't run as different users.
@@ -78,7 +80,7 @@ run_tests() {
 
     echo "=== Running $name tests ==="
     rm -f "$ARCHIVE"
-    cargo run --quiet -- touch "$ARCHIVE"
+    cargo run --quiet -- touch --path-size "$PATH_SIZE" "$ARCHIVE"
     cargo run --quiet -- mount "$ARCHIVE" --shell \
         "prove -v $paths :: --failures > $output 2>&1 || true"
     echo "  -> $output"


### PR DESCRIPTION
## Summary
- Replace NAME_MAX constant with `safename::validate_file()` for filename component validation in FUSE operations
- Map safename errors to proper errno codes (ENAMETOOLONG, EINVAL)
- Fix statfs namelen from 256 to 255 (POSIX NAME_MAX)
- Raise MAX_PATH_SIZE from 2048 to 4096 to match POSIX PATH_MAX
- Add `--path-size` option to `bale touch` command
- Update pjdfstest script to use 4096 path size

## Test plan
- [x] All cargo tests pass
- [x] pjdfstest ftruncate pure tests pass (60/60)
- [x] Clippy passes with no warnings

Closes #108