### PR TITLE
Document reserved .bale* paths and enforce in FUSE/writer (#119)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -206,7 +206,7 @@ Expected output goes in matching `.stdout` files.
 | LFH Stride | `30 + path_size + 8` (header + path + extra) |
 | Byte order | Little-endian                                |
 | Alignment  | 4096 bytes (configurable, 2^N)               |
-| Max path   | 256 bytes (configurable, 1-2048)             |
+| Max path   | 256 bytes (configurable, 1-4096)             |
 
 ### Archive Layout
 
@@ -235,7 +235,7 @@ Expected output goes in matching `.stdout` files.
 | 5      | 1    | Minor version (2)                       |
 | 6      | 1    | Patch version (0)                       |
 | 7      | 1    | Alignment power (2^N, e.g., 12 = 4096)  |
-| 8      | 2    | Path size (1-2048, little-endian)       |
+| 8      | 2    | Path size (1-4096, little-endian)       |
 | 10     | 4    | Next ID (u32, for stable entry IDs)     |
 | 14     | 144  | Reserved (zeros)                        |
 

--- a/docs/archive-layout.md
+++ b/docs/archive-layout.md
@@ -158,7 +158,7 @@ Stored as the EOCD comment field.
 | 5 | 1 | Minor version |
 | 6 | 1 | Patch version |
 | 7 | 1 | Alignment power (2^N bytes) |
-| 8 | 2 | Path size (1-2048) |
+| 8 | 2 | Path size (1-4096) |
 | 10 | 148 | Reserved (zeros) |
 
 ## Default Configuration
@@ -166,7 +166,7 @@ Stored as the EOCD comment field.
 | Setting | Default | Range |
 |---------|---------|-------|
 | Alignment | 4096 bytes (2^12) | 1 to 16 MB (2^0 to 2^24) |
-| Path size | 256 bytes | 1 to 2048 bytes |
+| Path size | 256 bytes | 1 to 4096 bytes |
 
 **Path length constraint:** If a file's path exceeds the configured `path_size`,
 archive creation fails with an error. Choose a `path_size` large enough for your
@@ -252,6 +252,35 @@ Total: 13450 bytes
 ```
 
 CD Entry offset for file at index `i`: `12288 + (i × 302)`
+
+## Reserved Paths
+
+Path components starting with `.bale` are reserved for internal format use.
+User content cannot use these paths; attempting to add entries with `.bale*`
+components will fail with a `ReservedPath` error.
+
+**Reserved pattern:** Any path component starting with `.bale`
+
+Examples of reserved paths (rejected):
+
+- `.bale` - Reserved prefix as filename
+- `.bale.txt` - Reserved prefix with extension
+- `.bale/file.txt` - Reserved directory
+- `foo/.bale/bar` - Reserved component in path
+- `.baledata` - Reserved prefix with suffix
+
+Examples of allowed paths (accepted):
+
+- `.bal` - Different prefix (not `.bale`)
+- `bale` - No leading dot
+- `foo.bale` - `.bale` not at component start
+- `mybale/file.txt` - Contains "bale" but not `.bale` prefix
+
+This reservation enables future format extensions such as:
+
+- Virtual `.bale/` metadata folder in FUSE mounts
+- Format-level metadata entries (e.g., `.bale/manifest.json`)
+- Internal bookkeeping entries
 
 ## ZIP Compatibility
 

--- a/src/archive/writer.rs
+++ b/src/archive/writer.rs
@@ -510,6 +510,9 @@ impl ArchiveWrite for Archive<MappedArchiveMut> {
         mode: u32,
         mtime: Option<std::time::SystemTime>,
     ) -> Result<(), BaleError> {
+        // Validate path against safename rules and reserved prefixes.
+        let _ = ArchivePath::try_from(path)?;
+
         let path_bytes = path.as_bytes();
         let path_size = self.path_size();
 

--- a/src/fuse/bale_fs_state.rs
+++ b/src/fuse/bale_fs_state.rs
@@ -9,7 +9,8 @@ use nix::sys::stat::{Mode, SFlag};
 
 use crate::fuse::{DIR_INO_START, FILE_INO_START, FuseDirEntry, ROOT_INO};
 use crate::{
-    ArchiveRead, ArchiveWrite, ArchiveWriter, CentralDirectoryHeader, DosDateTime, EntryKind,
+    ArchivePath, ArchiveRead, ArchiveWrite, ArchiveWriter, BaleError, CentralDirectoryHeader,
+    DosDateTime, EntryKind,
 };
 
 /// Default permission bits for regular files (rw-r--r--).
@@ -119,6 +120,19 @@ impl BaleFsState {
         } else {
             Ok(())
         }
+    }
+
+    /// Validates a full path using ArchivePath rules (safename + reserved prefix).
+    ///
+    /// Returns `Ok(())` if valid, or `Err(errno)` on failure.
+    fn validate_archive_path(path: &str) -> Result<(), i32> {
+        ArchivePath::try_from(path).map_err(|e| match e {
+            BaleError::UnsafeFilename(_) => libc::EINVAL,
+            BaleError::ReservedPath(_) => libc::EINVAL,
+            BaleError::InvalidPath => libc::EINVAL,
+            _ => libc::EIO,
+        })?;
+        Ok(())
     }
 
     /// Builds the directory tree from archive entries.
@@ -551,8 +565,9 @@ impl BaleFsState {
             format!("{}/{}", parent_path, name)
         };
 
-        // Check path length.
+        // Check path length and reserved prefix.
         self.validate_path_length(&full_path)?;
+        Self::validate_archive_path(&full_path)?;
 
         // Check directory doesn't already exist.
         if self.dir_inodes.contains_key(&full_path) {
@@ -701,8 +716,9 @@ impl BaleFsState {
             format!("{}/{}", parent_path, name)
         };
 
-        // Check path length.
+        // Check path length and reserved prefix.
         self.validate_path_length(&full_path)?;
+        Self::validate_archive_path(&full_path)?;
 
         // Check file doesn't already exist.
         if self.path_to_inode.contains_key(&full_path) {
@@ -841,8 +857,9 @@ impl BaleFsState {
             format!("{}/{}", new_parent_path, new_name)
         };
 
-        // Check new path length.
+        // Check new path length and reserved prefix.
         self.validate_path_length(&new_path)?;
+        Self::validate_archive_path(&new_path)?;
 
         // Check if source is a file or directory.
         let is_file = self.path_to_inode.contains_key(&old_path);
@@ -995,8 +1012,9 @@ impl BaleFsState {
             format!("{}/{}", parent_path, name)
         };
 
-        // Check path length.
+        // Check path length and reserved prefix.
         self.validate_path_length(&full_path)?;
+        Self::validate_archive_path(&full_path)?;
 
         // Check symlink doesn't already exist.
         if self.path_to_inode.contains_key(&full_path) {


### PR DESCRIPTION
## Summary
- Add "Reserved Paths" section to `docs/archive-layout.md` documenting `.bale*` reservation
- Update path size range from 2048 to 4096 in docs
- Add `ArchivePath` validation in `add_entry_with_mtime()` to reject reserved paths
- Add `validate_archive_path()` in FUSE and call from create_file, create_directory, create_symlink, rename_entry

## Bug Fix
FUSE was bypassing ArchivePath validation, allowing `.bale*` files/folders to be created. They would silently appear to succeed but fail at sync time. Now properly rejects at create time with `EINVAL`.

## Test plan
- [x] `touch .bale.txt` in FUSE mount fails with "Invalid argument"
- [x] `mkdir .bale` in FUSE mount fails with "Invalid argument"
- [x] All cargo tests pass
- [x] Clippy passes

Closes #119