### PR TITLE
Prepare v0.1.0 release (#122)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,8 +5,13 @@
 !.gitignore
 !Cargo.lock
 !Cargo.toml
+!CHANGELOG.md
 !CLAUDE.md
+!CODE_OF_CONDUCT.md
+!CONTRIBUTING.md
 !README.md
+!SECURITY.md
+!LICENSE.txt
 !.markdownlintrc
 !clippy.toml
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,54 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0] - 2025-01-14
+
+### Added
+
+#### Core Library
+
+- ZIP-compatible archive format with fixed-stride entries for O(1) random access
+- Memory-mapped I/O with shared file locking for concurrent reads
+- Append-only writer with automatic alignment (4096 bytes default)
+- Configurable path size (1-4096 bytes) and alignment (up to 16 MB)
+- ZIP64 support for large archives (>65535 entries, >4GB)
+- Stable entry IDs stored in ZIP-compatible extra field
+- Path validation via `safename` crate (blocks shell metacharacters, control chars)
+- Reserved `.bale*` paths for future format extensions
+
+#### CLI Commands
+
+- `touch` - Create empty archive or update mtime
+- `add` - Add files with optional `--prefix`
+- `list` - List entries with `ls -alF` style output
+- `extract` - Extract entries to directory
+- `delete` - Remove entries from archive
+- `compact` - Reclaim space and deduplicate paths
+- `check` - Verify archive integrity with `--fix` option
+- `mount` - FUSE filesystem with read/write support
+
+#### FUSE Filesystem
+
+- Full read/write support (create, modify, delete files)
+- Directory operations (mkdir, rmdir)
+- Symlink support
+- File permissions (chmod) for files, directories, and symlinks
+- Timestamp modification (utimensat, mtime)
+- Interactive shell mode (`--shell`)
+- Background daemon mode (`--background`)
+- Read-only mode (`--read-only`)
+- Proper error handling (EPERM for chown, ENOSYS for unsupported ops)
+
+### Security
+
+- Safe filename validation blocks path traversal and shell injection
+- Reserved paths prevent conflicts with format extensions
+
+[Unreleased]: https://github.com/theroyalwhee0/bale/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/theroyalwhee0/bale/releases/tag/v0.1.0

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,84 @@
+
+# Contributor Covenant 3.0 Code of Conduct
+
+## Our Pledge
+
+We pledge to make our community welcoming, safe, and equitable for all.
+
+We are committed to fostering an environment that respects and promotes the dignity, rights, and contributions of all individuals, regardless of characteristics including race, ethnicity, caste, color, age, physical characteristics, neurodiversity, disability, sex or gender, gender identity or expression, sexual orientation, language, philosophy or religion, national or social origin, socio-economic position, level of education, or other status. The same privileges of participation are extended to everyone who participates in good faith and in accordance with this Covenant.
+
+## Encouraged Behaviors
+
+While acknowledging differences in social norms, we all strive to meet our community's expectations for positive behavior. We also understand that our words and actions may be interpreted differently than we intend based on culture, background, or native language.
+
+With these considerations in mind, we agree to behave mindfully toward each other and act in ways that center our shared values, including:
+
+1. Respecting the **purpose of our community**, our activities, and our ways of gathering.
+2. Engaging **kindly and honestly** with others.
+3. Respecting **different viewpoints** and experiences.
+4. **Taking responsibility** for our actions and contributions.
+5. Gracefully giving and accepting **constructive feedback**.
+6. Committing to **repairing harm** when it occurs.
+7. Behaving in other ways that promote and sustain the **well-being of our community**.
+
+## Restricted Behaviors
+
+We agree to restrict the following behaviors in our community. Instances, threats, and promotion of these behaviors are violations of this Code of Conduct.
+
+1. **Harassment.** Violating explicitly expressed boundaries or engaging in unnecessary personal attention after any clear request to stop.
+2. **Character attacks.** Making insulting, demeaning, or pejorative comments directed at a community member or group of people.
+3. **Stereotyping or discrimination.** Characterizing anyone’s personality or behavior on the basis of immutable identities or traits.
+4. **Sexualization.** Behaving in a way that would generally be considered inappropriately intimate in the context or purpose of the community.
+5. **Violating confidentiality**. Sharing or acting on someone's personal or private information without their permission.
+6. **Endangerment.** Causing, encouraging, or threatening violence or other harm toward any person or group.
+7. Behaving in other ways that **threaten the well-being** of our community.
+
+### Other Restrictions
+
+1. **Misleading identity.** Impersonating someone else for any reason, or pretending to be someone else to evade enforcement actions.
+2. **Failing to credit sources.** Not properly crediting the sources of content you contribute.
+3. **Promotional materials**. Sharing marketing or other commercial content in a way that is outside the norms of the community.
+4. **Irresponsible communication.** Failing to responsibly present content which includes, links or describes any other restricted behaviors.
+
+## Reporting an Issue
+
+Tensions can occur between community members even when they are trying their best to collaborate. Not every conflict represents a code of conduct violation, and this Code of Conduct reinforces encouraged behaviors and norms that can help avoid conflicts and minimize harm.
+
+When an incident does occur, it is important to report it promptly. To report a possible violation, **Please email <hismajesty@theroyalwhee.com> to report any issues. Please include 'COMMUNITY INCIDENT' in the subject to improve classification of the email.**
+
+Community Moderators take reports of violations seriously and will make every effort to respond in a timely manner. They will investigate all reports of code of conduct violations, reviewing messages, logs, and recordings, or interviewing witnesses and other participants. Community Moderators will keep investigation and enforcement actions as transparent as possible while prioritizing safety and confidentiality. In order to honor these values, enforcement actions are carried out in private with the involved parties, but communicating to the whole community may be part of a mutually agreed upon resolution.
+
+## Addressing and Repairing Harm
+
+If an investigation by the Community Moderators finds that this Code of Conduct has been violated, the following enforcement ladder may be used to determine how best to repair harm, based on the incident's impact on the individuals involved and the community as a whole. Depending on the severity of a violation, lower rungs on the ladder may be skipped.
+
+1) Warning
+   1) Event: A violation involving a single incident or series of incidents.
+   2) Consequence: A private, written warning from the Community Moderators.
+   3) Repair: Examples of repair include a private written apology, acknowledgement of responsibility, and seeking clarification on expectations.
+2) Temporarily Limited Activities
+   1) Event: A repeated incidence of a violation that previously resulted in a warning, or the first incidence of a more serious violation.
+   2) Consequence: A private, written warning with a time-limited cooldown period designed to underscore the seriousness of the situation and give the community members involved time to process the incident. The cooldown period may be limited to particular communication channels or interactions with particular community members.
+   3) Repair: Examples of repair may include making an apology, using the cooldown period to reflect on actions and impact, and being thoughtful about re-entering community spaces after the period is over.
+3) Temporary Suspension
+   1) Event: A pattern of repeated violation which the Community Moderators have tried to address with warnings, or a single serious violation.
+   2) Consequence: A private written warning with conditions for return from suspension. In general, temporary suspensions give the person being suspended time to reflect upon their behavior and possible corrective actions.
+   3) Repair: Examples of repair include respecting the spirit of the suspension, meeting the specified conditions for return, and being thoughtful about how to reintegrate with the community when the suspension is lifted.
+4) Permanent Ban
+   1) Event: A pattern of repeated code of conduct violations that other steps on the ladder have failed to resolve, or a violation so serious that the Community Moderators determine there is no way to keep the community safe with this person as a member.
+   2) Consequence: Access to all community spaces, tools, and communication channels is removed. In general, permanent bans should be rarely used, should have strong reasoning behind them, and should only be resorted to if working through other remedies has failed to change the behavior.
+   3) Repair: There is no possible repair in cases of this severity.
+
+This enforcement ladder is intended as a guideline. It does not limit the ability of Community Managers to use their discretion and judgment, in keeping with the best interests of our community.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public or other spaces. Examples of representing our community include using an official email address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Attribution
+
+This Code of Conduct is adapted from the Contributor Covenant, version 3.0, permanently available at [https://www.contributor-covenant.org/version/3/0/](https://www.contributor-covenant.org/version/3/0/).
+
+Contributor Covenant is stewarded by the Organization for Ethical Source and licensed under CC BY-SA 4.0. To view a copy of this license, visit [https://creativecommons.org/licenses/by-sa/4.0/](https://creativecommons.org/licenses/by-sa/4.0/)
+
+For answers to common questions about Contributor Covenant, see the FAQ at [https://www.contributor-covenant.org/faq](https://www.contributor-covenant.org/faq). Translations are provided at [https://www.contributor-covenant.org/translations](https://www.contributor-covenant.org/translations). Additional enforcement and community guideline resources can be found at [https://www.contributor-covenant.org/resources](https://www.contributor-covenant.org/resources). The enforcement ladder was inspired by the work of [Mozilla's code of conduct team](https://github.com/mozilla/inclusion).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,114 @@
+# Contributing to bale
+
+Thank you for your interest in contributing to `bale`! This document provides guidelines for contributing to the project.
+
+## Code of Conduct
+
+This project adheres to the Contributor Covenant [Code of Conduct](CODE_OF_CONDUCT.md). By participating, you are expected to uphold this code.
+
+## How to Contribute
+
+### Reporting Bugs
+
+If you find a bug, please create an issue with:
+
+- A clear, descriptive title
+- Steps to reproduce the problem
+- Expected vs actual behavior
+- Your environment (OS, Rust version, `bale` version)
+- Any relevant error messages or logs
+
+### Suggesting Enhancements
+
+Enhancement suggestions are welcome! Please create an issue describing:
+
+- The motivation for the enhancement
+- A clear description of the proposed functionality
+- Any potential implementation considerations
+
+### Pull Requests
+
+1. **Fork and Clone**: Fork the repository and clone it locally
+2. **Create a Branch**: Create a feature branch from `main`
+3. **Make Changes**: Follow the project's coding standards (see below)
+4. **Test**: Ensure all tests pass with `cargo test`
+5. **Lint**: Run `cargo clippy` and address any warnings
+6. **Commit**: Write clear, descriptive commit messages
+7. **Push**: Push your branch to your fork
+8. **Open a PR**: Submit a pull request to the `main` branch
+
+## Development Setup
+
+```bash
+# Clone your fork
+git clone https://github.com/YOUR-USERNAME/bale.git
+cd bale
+
+# Build the project
+cargo build
+
+# Run tests
+cargo nextest run  # preferred
+cargo test         # alternative
+
+# Run clippy
+cargo clippy
+
+# Run all pre-commit checks
+git precommit --all
+```
+
+## Coding Standards
+
+This project maintains strict code quality standards:
+
+### Required Practices
+
+- **Comprehensive documentation**: All items (public and private) must be documented
+  - Include `# Errors`, `# Panics`, and `# Safety` sections where applicable
+- **No direct output**: Do not use `println!` or `eprintln!` in library code
+- **One item per file**: Generally, place one public item (struct, enum, or trait) per file
+  - File names should match the item name
+  - Include a comment if violating this guideline
+
+### Code Organization
+
+- **Module structure**: `mod.rs` files should only contain module declarations and re-exports
+- **Error handling**: Use `Result` types with `BaleError`
+- **Testing**: Add tests for new functionality in `#[cfg(test)]` modules
+- **Feature flags**: Use feature flags for optional functionality (fuse, compact)
+
+### Whitelist .gitignore
+
+This project uses a whitelist approach to version control. Only explicitly allowed files are tracked. When adding new file types, update `.gitignore` to include them with specific extensions.
+
+## Testing
+
+- Write unit tests for new functionality
+- Test different feature flag combinations
+- Ensure tests pass with `cargo test`
+- Consider property-based tests with proptest for edge cases
+- FUSE tests require fusermount3 to be available
+
+## Documentation
+
+- Update README.md for user-facing changes
+- Add rustdoc comments for all public APIs
+- Include examples in documentation where helpful
+- Run `cargo doc --open` to preview documentation
+
+## Dependencies
+
+- Keep dependencies minimal and well-vetted
+- Discuss new dependencies before adding them
+- Pin exact versions (e.g., `"2.0.17"` not `"2"`)
+- All dependencies belong in the workspace root `Cargo.toml`
+
+## Questions?
+
+If you have questions about contributing, feel free to:
+
+- Open an issue for discussion
+- Check existing issues and pull requests for context
+
+Thank you for contributing to `bale`!

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ exclude = [
     "SECURITY.md",
     ".markdownlintrc",
     "clippy.toml",
+    "docs/",
 ]
 
 [[bin]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,19 @@ version = "0.1.0"
 authors = ["Adam Mill <hismajesty@theroyalwhee.com>"]
 edition = "2024"
 rust-version = "1.89.0"
+description = "A mmap-first, fixed-stride zip-like pack format"
+license = "Apache-2.0"
+repository = "https://github.com/theroyalwhee0/bale"
+keywords = ["archive", "zip", "mmap", "pack", "fuse"]
+categories = ["compression", "filesystem"]
+exclude = [
+    "CLAUDE.md",
+    "CODE_OF_CONDUCT.md",
+    "CONTRIBUTING.md",
+    "SECURITY.md",
+    ".markdownlintrc",
+    "clippy.toml",
+]
 
 [[bin]]
 name = "bale"
@@ -18,26 +31,26 @@ compact = ["reader", "writer"]
 cli = ["reader", "writer", "dep:clap", "dep:env_logger"]
 fuse = ["cli", "dep:fuser"]
 bin = ["compact", "fuse"]
+# Enable integration tests requiring external tools (zipinfo, unzip, file, fusermount).
+integration-tests = []
 
 [dependencies]
-# Core utilities
+# General.
 thiserror = "2.0.17"
 chrono = "0.4.42"
-tempfile = "3.24.0"
-safename = { version = "0.1.0", features = ["medium"] }
 nix = { version = "0.30.1", default-features = false, features = ["fs", "process", "user"] }
+crc32fast = "1.5.0"
+zerocopy = { version = "0.8.31", features = ["derive"] }
 
-# Logging
+# Logging.
 log = "0.4.29"
 env_logger = { version = "0.11.8", optional = true }
 
-# File I/O
+# File System.
+tempfile = "3.24.0"
+safename = { version = "0.1.0", features = ["medium"] }
 fs4 = "0.13.1"
 memmap2 = "0.9.9"
-
-# Archive format
-crc32fast = "1.5.0"
-zerocopy = { version = "0.8.31", features = ["derive"] }
 
 # CLI (optional)
 clap = { version = "4", features = ["derive"], optional = true }

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # bale
 
+> **Warning**: This project is a work-in-progress. It has known bugs, incomplete
+> features, and the API will change. Use at your own risk.
+
 A Rust library and CLI for working with bale archives - a mmap-first, zero-copy
 zip-compatible archive format with fixed-stride entries for efficient random
 access.
@@ -139,4 +142,11 @@ cargo fmt
 
 ## Status
 
-Early development. The API is not yet stable.
+Version 0.1.0. The format is stable but the API may change in future releases.
+
+## License & Copyright
+
+Licensed under the Apache License, Version 2.0. See [LICENSE.txt](LICENSE.txt)
+for details.
+
+Copyright 2025 Adam Mill

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,56 @@
+# Security Policy
+
+## Supported Versions
+
+The following versions of `bale` are currently supported with security updates:
+
+| Version | Supported          |
+| ------- | ------------------ |
+| 0.1.x   | :white_check_mark: |
+| < 0.1   | :x:                |
+
+## Reporting a Vulnerability
+
+We take the security of `bale` seriously.
+
+### How to Report
+
+**Please do not report security vulnerabilities through public GitHub issues.**
+
+Instead, please report security vulnerabilities via one of the following methods:
+
+1. **GitHub Security Advisories** (preferred): Use GitHub's [private vulnerability reporting](https://github.com/theroyalwhee0/bale/security/advisories/new)
+2. **Email**: Send to [security@theroyalwhee.com](mailto:security@theroyalwhee.com). See <https://www.theroyalwhee.com/security/policy/>
+
+### What to Include
+
+Please include as much of the following information as possible:
+
+- Type of vulnerability (e.g., path traversal, archive parsing, etc.)
+- Step-by-step instructions to reproduce the issue
+- Affected versions or commits
+- Potential impact of the vulnerability
+- Any suggested fixes or mitigations
+
+### What to Expect
+
+- **Initial Response**: Within 72 hours of your report
+- **Status Update**: Within 2 weeks
+- **Fix Timeline**: Based on severity and complexity
+- **Credit**: Security researchers will be credited in release notes unless they prefer to remain anonymous
+
+### Security Scope
+
+Security issues of particular concern for `bale` include:
+
+- Path traversal vulnerabilities in archive extraction
+- Zip bomb or decompression bomb attacks
+- Memory safety issues in mmap handling
+- Arbitrary file overwrite during extraction
+- Symlink attacks
+- FUSE filesystem escape vulnerabilities
+- Filename validation bypass allowing dangerous paths
+- Dependency vulnerabilities
+- Supply chain security issues
+
+Thank you for helping keep `bale` and its users safe!

--- a/build.rs
+++ b/build.rs
@@ -162,10 +162,13 @@ fn add_profile(file: &mut File) -> io::Result<()> {
     const RELEASE: &str = "release";
     const DEBUG: &str = "debug";
 
-    // Determine if we're building in release mode
+    // Determine build profile, validating it's a known value.
     let profile = env::var(PROFILE).expect("Expected PROFILE to be set");
-    let is_release = profile == RELEASE;
-    let mode = if is_release { RELEASE } else { DEBUG };
+    let mode = match profile.as_str() {
+        RELEASE => RELEASE,
+        DEBUG => DEBUG,
+        _ => panic!("Unknown PROFILE '{profile}', expected '{RELEASE}' or '{DEBUG}'"),
+    };
 
     // If EXPECT_PROFILE is defined, verify it matches our current profile.
     if let Ok(expected) = env::var(EXPECT_PROFILE)

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,5 +1,5 @@
 disallowed-methods = [
     { path = "std::ffi::OsStr::to_string_lossy", reason = "leads to loss of information; use to_str() with proper error handling" },
     { path = "std::path::Path::to_string_lossy", reason = "leads to loss of information; use to_str() with proper error handling" },
-    { path = "std::string::String::from_utf8_lossy", reason = "use from_utf8() and handle errors explicitly" },
+    { path = "std::string::String::from_utf8_lossy", reason = "leads to loss of information; use from_utf8() with proper error handling" },
 ]

--- a/src/bin/bale/cli.rs
+++ b/src/bin/bale/cli.rs
@@ -49,8 +49,8 @@ pub enum Command {
         files: Vec<PathBuf>,
     },
     /// List entries in a bale archive.
-    #[command(visible_alias = "list")]
-    Ls {
+    #[command(visible_alias = "ls")]
+    List {
         /// The archive to list.
         archive: PathBuf,
     },

--- a/src/bin/bale/main.rs
+++ b/src/bin/bale/main.rs
@@ -83,7 +83,7 @@ fn run(cli: Cli) -> Result<(), BaleCliError> {
         } => commands::delete::run(archive, &entries, ignore_missing),
 
         // Content access.
-        Command::Ls { archive } => commands::list::run(archive),
+        Command::List { archive } => commands::list::run(archive),
         Command::Extract {
             archive,
             output,

--- a/tests/README.md
+++ b/tests/README.md
@@ -59,6 +59,33 @@ These tests require external tools (`zipinfo`, `unzip`, `file`, `fusermount`):
 | `duplicate_paths.bale` | Same path appears multiple times |
 | `unsorted_cd.bale` | Central Directory not sorted alphabetically |
 
+## External Tools
+
+Integration tests require external tools. Install with:
+
+```bash
+# Debian/Ubuntu
+sudo apt install unzip file fuse3
+
+# Fedora
+sudo dnf install unzip file fuse3
+
+# Arch
+sudo pacman -S unzip file fuse3
+```
+
+| Tool | Package | Used By |
+|------|---------|---------|
+| `zipinfo` | unzip | ZIP structure verification |
+| `unzip` | unzip | ZIP extraction testing |
+| `file` | file | File type detection |
+| `fusermount3` | fuse3 | FUSE mount/unmount |
+
+The pjdfstest script additionally requires:
+
+- `prove` - Perl test harness (package: `perl`)
+- `pjdfstest` - POSIX compliance suite (clone from GitHub)
+
 ## Scripts (`bin/`)
 
 - `run-pjdfstest.sh` - Runs pjdfstest POSIX compliance suite against FUSE mount

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,14 +1,85 @@
-# Test Fixtures
+# Tests
 
-This directory contains binary fixtures used by integration tests.
+This directory contains integration tests for the bale CLI and library.
 
-## Regenerating Fixtures
+## Running Tests
 
 ```bash
+# Run all tests (integration tests requiring external tools are skipped)
+cargo test
+
+# Run all tests including integration tests
+cargo test --features integration-tests
+
+# Regenerate test fixtures
 cargo test --test fixtures -- --ignored
 ```
 
-## Files
+## Test Categories
 
-- `empty.bale` - Empty bale archive (22-byte EOCD only)
-- `single_file.bale` - Archive with single "hello.txt" containing "Hello, World!"
+### Unit Tests (always run)
+
+- `cli_commands.rs` - Tests bale CLI commands (touch, add, ls, delete, extract, check, compact)
+- `check_valid.rs` - Tests `bale check` on valid archives
+- `check_invalid.rs` - Tests `bale check` on invalid archives
+
+### Integration Tests (require `--features integration-tests`)
+
+These tests require external tools (`zipinfo`, `unzip`, `file`, `fusermount`):
+
+- `empty.rs` - Verifies empty archives with external zip tools
+- `single_file.rs` - Verifies single-file archives with external zip tools
+- `align_16k.rs` - Verifies 16KB-aligned archives with zipinfo
+- `path_2048.rs` - Verifies archives with 2048-byte path size
+- `fuse_read.rs` - FUSE mount read operations via `bale mount --shell`
+- `fuse_write.rs` - FUSE mount write operations (create, delete, rename, chmod)
+
+### Fixture Generation (ignored by default)
+
+- `fixtures.rs` - Generates all test fixtures; run with `--ignored`
+
+## Test Fixtures
+
+### Valid Archives (`fixtures/valid/`)
+
+| File | Description |
+|------|-------------|
+| `empty.bale` | Empty archive (256-byte trailer only) |
+| `single_file.bale` | Single "hello.txt" with "Hello, World!" |
+| `multi_file.bale` | Multiple files and directories with various permissions |
+| `align_16k.bale` | Archive with 16KB data alignment |
+| `path_2048.bale` | Archive with 2048-byte path size |
+| `orphaned_data.bale` | Valid but not compacted (has gaps from deleted entries) |
+
+### Invalid Archives (`fixtures/invalid/`)
+
+| File | Description |
+|------|-------------|
+| `bad_crc.bale` | Corrupted CRC-32 checksum |
+| `duplicate_paths.bale` | Same path appears multiple times |
+| `unsorted_cd.bale` | Central Directory not sorted alphabetically |
+
+## Scripts (`bin/`)
+
+- `run-pjdfstest.sh` - Runs pjdfstest POSIX compliance suite against FUSE mount
+
+## Proptest Regressions (`proptest-regressions/`)
+
+Contains regression test cases discovered by proptest. These are automatically
+generated when proptest finds a failing case and should be committed to ensure
+the bug stays fixed.
+
+## trycmd Tests (`cmd/`)
+
+The `cmd/` directory contains trycmd test cases as TOML files with expected output:
+
+```text
+cmd/
+├── check_invalid/     # bale check on invalid archives
+├── check_valid/       # bale check on valid archives
+├── empty_archive/     # External tool tests (file, zipinfo, unzip)
+├── fuse_read/         # FUSE mount read tests
+├── single_file/       # External tool tests on single-file archive
+├── align_16k/         # zipinfo on 16KB-aligned archive
+└── path_2048/         # zipinfo on 2048-byte path archive
+```

--- a/tests/align_16k.rs
+++ b/tests/align_16k.rs
@@ -2,6 +2,7 @@
 
 /// Verifies align_16k.bale with zipinfo.
 #[test]
+#[cfg_attr(not(feature = "integration-tests"), ignore = "requires external tools")]
 fn cli_tools() {
     trycmd::TestCases::new()
         .case("tests/cmd/align_16k/*.toml")

--- a/tests/empty.rs
+++ b/tests/empty.rs
@@ -2,6 +2,7 @@
 
 /// Verifies empty.bale with file, zipinfo, and unzip.
 #[test]
+#[cfg_attr(not(feature = "integration-tests"), ignore = "requires external tools")]
 fn cli_tools() {
     trycmd::TestCases::new()
         .case("tests/cmd/empty_archive/*.toml")

--- a/tests/fuse_read.rs
+++ b/tests/fuse_read.rs
@@ -4,6 +4,7 @@
 
 /// Verifies FUSE read operations work correctly.
 #[test]
+#[cfg_attr(not(feature = "integration-tests"), ignore = "requires FUSE")]
 fn fuse_read_operations() {
     trycmd::TestCases::new()
         .case("tests/cmd/fuse_read/*.toml")

--- a/tests/fuse_write.rs
+++ b/tests/fuse_write.rs
@@ -1,6 +1,8 @@
 //! FUSE write operation integration tests.
 //!
 //! Tests file creation, deletion, and modification via `bale mount --shell`.
+//!
+//! These tests require FUSE support and are gated behind the `integration-tests` feature.
 
 use std::fs;
 use std::process::Command;
@@ -23,6 +25,7 @@ fn run_bale(args: &[&str]) -> (bool, String, String) {
 
 /// Create a file via FUSE mount.
 #[test]
+#[cfg_attr(not(feature = "integration-tests"), ignore = "requires FUSE")]
 fn fuse_create_file() {
     let dir = tempdir().unwrap();
     let archive = dir.path().join("test.bale");
@@ -54,6 +57,7 @@ fn fuse_create_file() {
 
 /// Create a directory via FUSE mount.
 #[test]
+#[cfg_attr(not(feature = "integration-tests"), ignore = "requires FUSE")]
 fn fuse_mkdir() {
     let dir = tempdir().unwrap();
     let archive = dir.path().join("test.bale");
@@ -80,6 +84,7 @@ fn fuse_mkdir() {
 
 /// Delete a file via FUSE mount.
 #[test]
+#[cfg_attr(not(feature = "integration-tests"), ignore = "requires FUSE")]
 fn fuse_unlink() {
     let dir = tempdir().unwrap();
     let archive = dir.path().join("test.bale");
@@ -106,6 +111,7 @@ fn fuse_unlink() {
 
 /// Delete a directory via FUSE mount.
 #[test]
+#[cfg_attr(not(feature = "integration-tests"), ignore = "requires FUSE")]
 fn fuse_rmdir() {
     let dir = tempdir().unwrap();
     let archive = dir.path().join("test.bale");
@@ -132,6 +138,7 @@ fn fuse_rmdir() {
 
 /// Rename a file via FUSE mount.
 #[test]
+#[cfg_attr(not(feature = "integration-tests"), ignore = "requires FUSE")]
 fn fuse_rename() {
     let dir = tempdir().unwrap();
     let archive = dir.path().join("test.bale");
@@ -162,6 +169,7 @@ fn fuse_rename() {
 
 /// Write to existing file via FUSE mount.
 #[test]
+#[cfg_attr(not(feature = "integration-tests"), ignore = "requires FUSE")]
 fn fuse_write_existing() {
     let dir = tempdir().unwrap();
     let archive = dir.path().join("test.bale");
@@ -199,6 +207,7 @@ fn fuse_write_existing() {
 
 /// Create nested directories via FUSE mount.
 #[test]
+#[cfg_attr(not(feature = "integration-tests"), ignore = "requires FUSE")]
 fn fuse_mkdir_nested() {
     let dir = tempdir().unwrap();
     let archive = dir.path().join("test.bale");
@@ -225,6 +234,7 @@ fn fuse_mkdir_nested() {
 
 /// Symlink operations via FUSE mount.
 #[test]
+#[cfg_attr(not(feature = "integration-tests"), ignore = "requires FUSE")]
 fn fuse_symlink() {
     let dir = tempdir().unwrap();
     let archive = dir.path().join("test.bale");
@@ -255,6 +265,7 @@ fn fuse_symlink() {
 
 /// getattr returns correct file size after write.
 #[test]
+#[cfg_attr(not(feature = "integration-tests"), ignore = "requires FUSE")]
 fn fuse_getattr_after_write() {
     let dir = tempdir().unwrap();
     let archive = dir.path().join("test.bale");
@@ -277,6 +288,7 @@ fn fuse_getattr_after_write() {
 /// Regression test: create() adds an initial entry, then sync_modified_to_archive()
 /// must delete before re-adding to avoid duplicates.
 #[test]
+#[cfg_attr(not(feature = "integration-tests"), ignore = "requires FUSE")]
 fn fuse_no_duplicate_entries() {
     let dir = tempdir().unwrap();
     let archive = dir.path().join("test.bale");
@@ -308,6 +320,7 @@ fn fuse_no_duplicate_entries() {
 
 /// setattr (chmod) via FUSE mount.
 #[test]
+#[cfg_attr(not(feature = "integration-tests"), ignore = "requires FUSE")]
 fn fuse_setattr_chmod() {
     let dir = tempdir().unwrap();
     let archive = dir.path().join("test.bale");

--- a/tests/path_2048.rs
+++ b/tests/path_2048.rs
@@ -2,6 +2,7 @@
 
 /// Verifies path_2048.bale with zipinfo.
 #[test]
+#[cfg_attr(not(feature = "integration-tests"), ignore = "requires external tools")]
 fn cli_tools() {
     trycmd::TestCases::new()
         .case("tests/cmd/path_2048/*.toml")

--- a/tests/single_file.rs
+++ b/tests/single_file.rs
@@ -2,6 +2,7 @@
 
 /// Verifies single_file.bale with file, zipinfo, and unzip.
 #[test]
+#[cfg_attr(not(feature = "integration-tests"), ignore = "requires external tools")]
 fn cli_tools() {
     trycmd::TestCases::new()
         .case("tests/cmd/single_file/*.toml")


### PR DESCRIPTION
## Summary

- Add package metadata to Cargo.toml (description, license, repository, keywords, categories)
- Add exclude list for files not needed in published crate (CLAUDE.md, docs/, etc.)
- Add `integration-tests` feature to gate tests requiring external tools
- Add CHANGELOG.md, CONTRIBUTING.md, SECURITY.md, CODE_OF_CONDUCT.md, LICENSE.txt
- Update README with warning banner and license section
- Reverse list/ls CLI alias (list is primary, ls is alias)
- Validate build profile in build.rs with explicit match
- Update tests/README.md with current test structure and external tool requirements

## Test plan

- [x] `cargo test` passes (integration tests skipped by default)
- [x] `cargo test --features integration-tests` passes
- [x] `cargo publish --dry-run` succeeds
- [x] Package size: 120 files, 101 KiB compressed

Closes #122