### PR TITLE
Add Crc(u32) newtype for strong CRC typing

### DIFF
--- a/src/archive/reader.rs
+++ b/src/archive/reader.rs
@@ -263,12 +263,10 @@ impl ArchiveRead for Archive<MappedArchive> {
     ///
     /// Returns an error if the data cannot be read or the CRC does not match.
     fn verify_crc(&self, entry: &EntryRow) -> Result<(), BaleError> {
-        let offset = entry.data_offset.get();
-        if offset == 0 {
-            // No data block; nothing to verify.
+        let Some(stored_crc) = entry.crc().get() else {
+            // No CRC; nothing to verify (directory or empty entry).
             return Ok(());
-        }
-        let stored_crc = entry.crc32c.get();
+        };
         let data = self.read_data(entry)?;
         let computed_crc = crc32fast::hash(data);
 
@@ -464,7 +462,7 @@ impl ArchiveRead for Archive<MappedArchive> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::format::FileHeader;
+    use crate::format::{Crc, FileHeader};
     use zerocopy::IntoBytes;
 
     /// Default path size used in tests.
@@ -511,13 +509,16 @@ mod tests {
             /// Offset in the archive where the data block starts.
             offset: u64,
             /// CRC-32 of the data bytes.
-            crc: u32,
+            crc: Crc,
         }
         let mut data_infos: Vec<DataInfo> = Vec::new();
 
         for entry in entries {
             if entry.data.is_empty() {
-                data_infos.push(DataInfo { offset: 0, crc: 0 });
+                data_infos.push(DataInfo {
+                    offset: 0,
+                    crc: Crc::NONE,
+                });
                 continue;
             }
             // Pad to alignment.
@@ -527,7 +528,7 @@ mod tests {
             buf.extend(std::iter::repeat_n(0u8, padding));
 
             let data_offset = buf.len() as u64;
-            let crc = crc32fast::hash(entry.data);
+            let crc = Crc::compute(entry.data);
 
             // Write raw data (no header).
             buf.extend_from_slice(entry.data);

--- a/src/format/crc.rs
+++ b/src/format/crc.rs
@@ -1,0 +1,85 @@
+//! CRC-32 newtype for strong typing.
+
+/// CRC-32 checksum with semantic zero handling.
+///
+/// Wraps a raw `u32` CRC value. The value `0` represents "no CRC" (used by
+/// directories and empty entries), accessed via [`get()`](Self::get) which
+/// returns `None` for zero and `Some(value)` for non-zero.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Crc(u32);
+
+impl Crc {
+    /// No CRC (value 0). Used for directories and empty data blocks.
+    pub const NONE: Self = Self(0);
+
+    /// Creates a `Crc` from a raw `u32` value.
+    #[must_use]
+    pub fn new(value: u32) -> Self {
+        Self(value)
+    }
+
+    /// Computes the CRC-32 checksum of the given data.
+    ///
+    /// Returns [`Crc::NONE`] for empty data.
+    #[must_use]
+    pub fn compute(data: &[u8]) -> Self {
+        if data.is_empty() {
+            return Self::NONE;
+        }
+        Self(crc32fast::hash(data))
+    }
+
+    /// Returns the CRC value, or `None` if absent (zero).
+    #[must_use]
+    pub fn get(self) -> Option<u32> {
+        if self.0 == 0 { None } else { Some(self.0) }
+    }
+
+    /// Returns the raw `u32` value for serialization.
+    #[must_use]
+    pub fn to_u32(self) -> u32 {
+        self.0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `Crc::NONE` has value 0 and `.get()` returns `None`.
+    #[test]
+    fn none_is_zero() {
+        assert_eq!(Crc::NONE.to_u32(), 0);
+        assert_eq!(Crc::NONE.get(), None);
+    }
+
+    /// Non-zero value is accessible via `.get()`.
+    #[test]
+    fn non_zero_get() {
+        let crc = Crc::new(0xDEAD_BEEF);
+        assert_eq!(crc.get(), Some(0xDEAD_BEEF));
+        assert_eq!(crc.to_u32(), 0xDEAD_BEEF);
+    }
+
+    /// `Crc::compute` on empty data returns `NONE`.
+    #[test]
+    fn compute_empty() {
+        assert_eq!(Crc::compute(b""), Crc::NONE);
+    }
+
+    /// `Crc::compute` on non-empty data returns a non-zero CRC.
+    #[test]
+    fn compute_non_empty() {
+        let crc = Crc::compute(b"Hello, World!");
+        assert!(crc.get().is_some());
+        assert_eq!(crc.to_u32(), crc32fast::hash(b"Hello, World!"));
+    }
+
+    /// Equality compares inner values.
+    #[test]
+    fn equality() {
+        assert_eq!(Crc::new(42), Crc::new(42));
+        assert_ne!(Crc::new(42), Crc::new(43));
+        assert_eq!(Crc::NONE, Crc::new(0));
+    }
+}

--- a/src/format/entry_row.rs
+++ b/src/format/entry_row.rs
@@ -1,6 +1,7 @@
 //! Entry table row containing per-entry metadata.
 
 use crate::EntryKind;
+use crate::format::Crc;
 use zerocopy::byteorder::little_endian::{I64, U32, U64};
 use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout, Unaligned};
 
@@ -67,7 +68,7 @@ impl EntryRow {
     #[allow(clippy::too_many_arguments)]
     pub fn new_file(
         entry_id: u32,
-        crc32c: u32,
+        crc: Crc,
         data_offset: u64,
         file_size: u64,
         block_size: u64,
@@ -77,7 +78,7 @@ impl EntryRow {
     ) -> Self {
         Self {
             entry_id: U32::new(entry_id),
-            crc32c: U32::new(crc32c),
+            crc32c: U32::new(crc.to_u32()),
             data_offset: U64::new(data_offset),
             file_size: U64::new(file_size),
             block_size: U64::new(block_size),
@@ -93,12 +94,12 @@ impl EntryRow {
     /// Creates a new `EntryRow` for a directory.
     ///
     /// Directories have no data block (`data_offset = 0`, `file_size = 0`,
-    /// `block_size = 0`) and no CRC (`crc32c = 0`).
+    /// `block_size = 0`) and no CRC.
     #[must_use]
     pub fn new_directory(entry_id: u32, created_time: i64, modified_time: i64, mode: u32) -> Self {
         Self {
             entry_id: U32::new(entry_id),
-            crc32c: U32::new(0),
+            crc32c: U32::new(Crc::NONE.to_u32()),
             data_offset: U64::new(0),
             file_size: U64::new(0),
             block_size: U64::new(0),
@@ -109,6 +110,12 @@ impl EntryRow {
             flags: 0,
             reserved: [0u8; Self::RESERVED_SIZE],
         }
+    }
+
+    /// Returns the CRC-32 checksum for this entry.
+    #[must_use]
+    pub fn crc(&self) -> Crc {
+        Crc::new(self.crc32c.get())
     }
 
     /// Returns the entry kind based on the mode field.
@@ -134,7 +141,7 @@ mod tests {
     fn new_file() {
         let row = EntryRow::new_file(
             1,
-            0xDEAD_BEEF,
+            Crc::new(0xDEAD_BEEF),
             4096,
             1024,
             1024,
@@ -143,7 +150,7 @@ mod tests {
             0o100644,
         );
         assert_eq!(row.entry_id.get(), 1);
-        assert_eq!(row.crc32c.get(), 0xDEAD_BEEF);
+        assert_eq!(row.crc().get(), Some(0xDEAD_BEEF));
         assert_eq!(row.data_offset.get(), 4096);
         assert_eq!(row.file_size.get(), 1024);
         assert_eq!(row.block_size.get(), 1024);
@@ -160,7 +167,7 @@ mod tests {
     fn new_directory() {
         let row = EntryRow::new_directory(3, 1_700_000_000_000, 1_700_000_001_000, 0o040755);
         assert_eq!(row.entry_id.get(), 3);
-        assert_eq!(row.crc32c.get(), 0);
+        assert_eq!(row.crc().get(), None);
         assert_eq!(row.data_offset.get(), 0);
         assert_eq!(row.file_size.get(), 0);
         assert_eq!(row.block_size.get(), 0);
@@ -172,20 +179,20 @@ mod tests {
     /// Entry kind is correctly derived from mode.
     #[test]
     fn kind_from_mode() {
-        let file = EntryRow::new_file(1, 0, 4096, 100, 100, 0, 0, 0o100644);
+        let file = EntryRow::new_file(1, Crc::NONE, 4096, 100, 100, 0, 0, 0o100644);
         assert_eq!(file.kind(), EntryKind::File);
 
         let dir = EntryRow::new_directory(2, 0, 0, 0o040755);
         assert_eq!(dir.kind(), EntryKind::Directory);
 
-        let symlink = EntryRow::new_file(3, 0, 4096, 11, 11, 0, 0, 0o120777);
+        let symlink = EntryRow::new_file(3, Crc::NONE, 4096, 11, 11, 0, 0, 0o120777);
         assert_eq!(symlink.kind(), EntryKind::Symlink);
     }
 
     /// Negative timestamps are supported (pre-epoch dates).
     #[test]
     fn negative_timestamps() {
-        let row = EntryRow::new_file(1, 0, 4096, 100, 100, -1_000_000, -500_000, 0o100644);
+        let row = EntryRow::new_file(1, Crc::NONE, 4096, 100, 100, -1_000_000, -500_000, 0o100644);
         assert_eq!(row.created_time.get(), -1_000_000);
         assert_eq!(row.modified_time.get(), -500_000);
     }
@@ -195,7 +202,7 @@ mod tests {
     fn roundtrip() {
         let row = EntryRow::new_file(
             42,
-            0xCAFE_BABE,
+            Crc::new(0xCAFE_BABE),
             8192,
             65536,
             32768,
@@ -208,7 +215,7 @@ mod tests {
 
         let restored = EntryRow::ref_from_bytes(bytes).unwrap();
         assert_eq!(restored.entry_id.get(), 42);
-        assert_eq!(restored.crc32c.get(), 0xCAFE_BABE);
+        assert_eq!(restored.crc().get(), Some(0xCAFE_BABE));
         assert_eq!(restored.data_offset.get(), 8192);
         assert_eq!(restored.file_size.get(), 65536);
         assert_eq!(restored.block_size.get(), 32768);

--- a/src/format/mod.rs
+++ b/src/format/mod.rs
@@ -3,6 +3,8 @@
 //! This module contains the on-disk layout structures that define the bale
 //! archive format. See `docs/bale-spec.md` for the full specification.
 
+/// CRC-32 newtype for strong typing.
+mod crc;
 /// Directory table row mapping path to entry ID.
 mod directory_row;
 /// Entry table row (64 bytes) with per-entry metadata.
@@ -12,6 +14,7 @@ mod file_header;
 /// Archive trailer (64 bytes) at end of file.
 mod trailer;
 
+pub use crc::Crc;
 pub use directory_row::DirectoryRow;
 pub use entry_row::EntryRow;
 pub use file_header::FileHeader;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,5 +44,5 @@ pub use archive_path::ArchivePath;
 pub use compact::{CompactStats, RenameStats, compact, rename_duplicates};
 pub use entry_kind::EntryKind;
 pub use error::BaleError;
-pub use format::{DirectoryRow, EntryRow, FileHeader, Trailer};
+pub use format::{Crc, DirectoryRow, EntryRow, FileHeader, Trailer};
 pub use mmap::{MappedArchive, MappedArchiveMut};


### PR DESCRIPTION
## Summary

- Add `Crc` newtype wrapping raw `u32` CRC values with semantic zero handling
- `Crc::get() -> Option<u32>` maps 0 to `None`, forcing callers to handle the "no CRC" case
- `Crc::compute(&[u8])` wraps `crc32fast::hash` with empty-data handling
- `EntryRow::new_file()` now accepts `Crc` instead of raw `u32`
- `EntryRow::crc()` accessor returns `Crc` from the on-disk field
- Reader `verify_crc` uses `let-else` on `Crc::get()` for cleaner control flow

## Test plan

- [x] All 147 tests pass
- [x] Clippy clean
- [x] New unit tests for `Crc` (none_is_zero, non_zero_get, compute_empty, compute_non_empty, equality)

Closes #144