### PR TITLE
Remove panics: return Result instead of expect()

### DIFF
--- a/src/archive/archive_read.rs
+++ b/src/archive/archive_read.rs
@@ -16,11 +16,10 @@ pub trait ArchiveRead {
 
     /// Returns the configured alignment for this archive.
     ///
-    /// # Panics
+    /// # Errors
     ///
-    /// Panics if `alignment_power` is invalid. This cannot happen for archives
-    /// opened via [`open()`](super::Archive::open) since validation occurs on construction.
-    fn alignment(&self) -> u32;
+    /// Returns an error if `alignment_power` is invalid.
+    fn alignment(&self) -> Result<u32, BaleError>;
 
     /// Returns the path for the entry at the given index as a zero-copy `ArchivePath`.
     ///
@@ -85,7 +84,11 @@ pub trait ArchiveRead {
     ///
     /// Orphaned data exists when there are data blocks not referenced by any
     /// entry in the entry table.
-    fn has_orphaned_data(&self) -> bool;
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the archive metadata is corrupted.
+    fn has_orphaned_data(&self) -> Result<bool, BaleError>;
 
     /// Returns a file entry by path.
     ///

--- a/src/archive/reader.rs
+++ b/src/archive/reader.rs
@@ -50,15 +50,21 @@ impl Archive<MappedArchive> {
     /// Returns a zero-copy slice of the entry table from the mmap.
     ///
     /// Returns an empty slice when the archive has no entries.
-    fn entry_table(&self) -> &[EntryRow] {
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the entry table bytes cannot be interpreted as
+    /// a valid `[EntryRow]` slice (e.g., corrupted archive data).
+    fn entry_table(&self) -> Result<&[EntryRow], BaleError> {
         let count = self.trailer.entry_count.get() as usize;
         if count == 0 {
-            return &[];
+            return Ok(&[]);
         }
         let offset = self.trailer.entry_table_offset.get() as usize;
         let len = count * EntryRow::SIZE;
         let bytes = &self.mmap.as_bytes()[offset..offset + len];
-        <[EntryRow]>::ref_from_bytes(bytes).expect("entry table aligned and sized correctly")
+        <[EntryRow]>::ref_from_bytes(bytes)
+            .map_err(|e| BaleError::Corrupted(format!("invalid entry table: {e}")))
     }
 
     /// Returns the raw bytes of the directory table from the mmap.
@@ -88,8 +94,10 @@ impl Archive<MappedArchive> {
     }
 
     /// Finds an entry row by ID using binary search on the entry table.
+    ///
+    /// Returns `None` if the ID is not found or the entry table is corrupted.
     fn find_entry_row_by_id(&self, id: u32) -> Option<&EntryRow> {
-        let table = self.entry_table();
+        let table = self.entry_table().ok()?;
         table
             .binary_search_by_key(&id, |row| row.entry_id.get())
             .ok()
@@ -187,11 +195,11 @@ impl ArchiveRead for Archive<MappedArchive> {
 
     /// Returns the configured alignment.
     ///
-    /// # Panics
+    /// # Errors
     ///
-    /// Panics if alignment_power is invalid (cannot happen for validated archives).
-    fn alignment(&self) -> u32 {
-        self.trailer.alignment().expect("validated on construction")
+    /// Returns an error if `alignment_power` is invalid.
+    fn alignment(&self) -> Result<u32, BaleError> {
+        self.trailer.alignment()
     }
 
     /// Returns the path at the given directory table index.
@@ -326,15 +334,19 @@ impl ArchiveRead for Archive<MappedArchive> {
     }
 
     /// Checks for orphaned data blocks not referenced by any entry.
-    fn has_orphaned_data(&self) -> bool {
-        let entry_table = self.entry_table();
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the entry table or alignment is corrupted.
+    fn has_orphaned_data(&self) -> Result<bool, BaleError> {
+        let entry_table = self.entry_table()?;
         let referenced: HashSet<u64> = entry_table
             .iter()
             .map(|row| row.data_offset.get())
             .filter(|&offset| offset != 0)
             .collect();
 
-        let alignment = self.alignment() as u64;
+        let alignment = self.alignment()? as u64;
         let data_region_end = self.trailer.entry_table_offset.get();
 
         // Walk aligned offsets from the first alignment boundary after the file
@@ -342,7 +354,7 @@ impl ArchiveRead for Archive<MappedArchive> {
         let mut offset = {
             let start = FileHeader::SIZE as u64;
             if alignment == 0 {
-                return false;
+                return Ok(false);
             }
             // Round up to next alignment boundary.
             start.div_ceil(alignment) * alignment
@@ -352,11 +364,11 @@ impl ArchiveRead for Archive<MappedArchive> {
             // Each alignment boundary in the data region that is not referenced
             // by any entry is an orphaned data block.
             if !referenced.contains(&offset) {
-                return true;
+                return Ok(true);
             }
             offset += alignment;
         }
-        false
+        Ok(false)
     }
 
     /// Returns a file entry by path.
@@ -624,13 +636,13 @@ mod tests {
 
         assert_eq!(archive.entry_count(), 0);
         assert_eq!(archive.path_size(), TEST_PATH_SIZE as usize);
-        assert_eq!(archive.alignment(), TEST_ALIGNMENT);
+        assert_eq!(archive.alignment().unwrap(), TEST_ALIGNMENT);
         assert!(archive.iter_entries().next().is_none());
         assert!(archive.find_entry("hello.txt").is_none());
         assert!(archive.get_path(0).is_none());
         assert!(archive.is_sorted());
         assert!(archive.find_duplicates().is_empty());
-        assert!(!archive.has_orphaned_data());
+        assert!(!archive.has_orphaned_data().unwrap());
     }
 
     /// Single file entry can be found and read.

--- a/src/archive/writer.rs
+++ b/src/archive/writer.rs
@@ -183,7 +183,7 @@ impl Archive<MappedArchiveMut> {
         }
 
         // Pad to alignment boundary.
-        let alignment = self.trailer.alignment().expect("validated on construction") as usize;
+        let alignment = self.trailer.alignment()? as usize;
         let current = self.write_offset;
         let padding = (alignment - (current % alignment)) % alignment;
         if padding > 0 {
@@ -267,11 +267,11 @@ impl ArchiveRead for Archive<MappedArchiveMut> {
 
     /// Returns the configured alignment.
     ///
-    /// # Panics
+    /// # Errors
     ///
-    /// Panics if alignment_power is invalid (cannot happen for validated archives).
-    fn alignment(&self) -> u32 {
-        self.trailer.alignment().expect("validated on construction")
+    /// Returns an error if `alignment_power` is invalid.
+    fn alignment(&self) -> Result<u32, BaleError> {
+        self.trailer.alignment()
     }
 
     /// Returns the path at the given directory table index.
@@ -402,7 +402,11 @@ impl ArchiveRead for Archive<MappedArchiveMut> {
     }
 
     /// Checks for orphaned data blocks.
-    fn has_orphaned_data(&self) -> bool {
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the alignment is invalid.
+    fn has_orphaned_data(&self) -> Result<bool, BaleError> {
         let referenced: HashSet<u64> = self
             .entry_rows
             .iter()
@@ -410,20 +414,20 @@ impl ArchiveRead for Archive<MappedArchiveMut> {
             .filter(|&offset| offset != 0)
             .collect();
 
-        let alignment = self.alignment() as u64;
+        let alignment = self.alignment()? as u64;
         let data_region_end = self.write_offset as u64;
 
         let mut offset = {
             let start = FileHeader::SIZE as u64;
             if alignment == 0 {
-                return false;
+                return Ok(false);
             }
             start.div_ceil(alignment) * alignment
         };
 
         while offset < data_region_end {
             if !referenced.contains(&offset) {
-                return true;
+                return Ok(true);
             }
             // Skip to next alignment boundary past this data block.
             let entry = self
@@ -438,7 +442,7 @@ impl ArchiveRead for Archive<MappedArchiveMut> {
             };
             offset = next;
         }
-        false
+        Ok(false)
     }
 
     /// Returns a file entry by path.
@@ -773,7 +777,7 @@ mod tests {
         assert!(reader.iter_entries().next().is_none());
         assert!(reader.is_sorted());
         assert!(reader.find_duplicates().is_empty());
-        assert!(!reader.has_orphaned_data());
+        assert!(!reader.has_orphaned_data().unwrap());
     }
 
     /// Single file entry round-trips through writer and reader.

--- a/src/bin/bale/commands/add.rs
+++ b/src/bin/bale/commands/add.rs
@@ -21,7 +21,9 @@ pub fn run(
         let name = file.file_name().unwrap_or(file.as_os_str());
         let dest = Path::new(prefix).join(name);
         let entry_path = ArchivePath::try_from(dest)?;
-        let entry_str = entry_path.as_str().expect("path validated as UTF-8");
+        let entry_str = entry_path
+            .as_str()
+            .ok_or(BaleCliError::Bale(bale::BaleError::InvalidPath))?;
 
         writer.add_file(file, entry_str)?;
         added_count += 1;

--- a/src/bin/bale/commands/check.rs
+++ b/src/bin/bale/commands/check.rs
@@ -65,7 +65,7 @@ pub fn run(archive_path: impl AsRef<Path>, quiet: bool) -> Result<(), BaleCliErr
     }
 
     // Check orphaned data.
-    let has_orphaned_data = reader.has_orphaned_data();
+    let has_orphaned_data = reader.has_orphaned_data()?;
     if has_orphaned_data {
         errors.push("Archive contains orphaned data (run 'bale compact' to reclaim)".to_string());
     }

--- a/src/compact.rs
+++ b/src/compact.rs
@@ -80,7 +80,7 @@ pub fn compact(path: impl AsRef<Path>) -> Result<CompactStats, BaleError> {
 
     // Open existing archive for reading.
     let reader = ArchiveReader::open(path)?;
-    let alignment = reader.alignment();
+    let alignment = reader.alignment()?;
     let path_size = reader.path_size() as u16;
 
     // Collect entries, keeping only the last occurrence of each path (shadowing).
@@ -235,7 +235,7 @@ pub fn rename_duplicates(path: impl AsRef<Path>) -> Result<RenameStats, BaleErro
 
     // Open existing archive for reading.
     let reader = ArchiveReader::open(path)?;
-    let alignment = reader.alignment();
+    let alignment = reader.alignment()?;
     let path_size = reader.path_size() as u16;
 
     // First pass: count occurrences of each path.


### PR DESCRIPTION
## Summary

- Replace all `.expect()` calls in non-test code with proper `Result` propagation
- `entry_table()` now returns `Result<&[EntryRow], BaleError>` instead of panicking on corrupted data
- `alignment()` trait method returns `Result<u32, BaleError>` instead of panicking
- `has_orphaned_data()` trait method returns `Result<bool, BaleError>` to propagate alignment/entry table errors
- `add.rs` uses `.ok_or()` instead of `.expect()` for path validation

## Test plan

- [x] All 161 tests pass (`cargo nextest run`)
- [x] Clippy clean (`cargo clippy -- -D warnings`)
- [x] All pre-commit hooks pass
- [x] Zero `.expect()` calls remain in `src/`

Closes #136