### PR TITLE
Add entry ID overflow detection (#157)

### DIFF
--- a/src/archive/writer.rs
+++ b/src/archive/writer.rs
@@ -620,8 +620,11 @@ impl ArchiveWrite for Archive<MappedArchiveMut> {
         // Check path fits within path_size.
         let padded = self.pad_path(normalized_str)?;
 
-        // Assign entry ID.
+        // Assign entry ID, checking for overflow.
         let entry_id = self.trailer.next_id();
+        if entry_id == u32::MAX {
+            return Err(BaleError::ArchiveFull);
+        }
         self.trailer.set_next_id(entry_id + 1);
 
         // Write data block (returns offset and CRC).
@@ -1189,5 +1192,18 @@ mod tests {
         assert!(writer.find_by_id(99).is_none());
 
         writer.sync().unwrap();
+    }
+
+    /// Adding an entry when next_id is u32::MAX returns ArchiveFull.
+    #[test]
+    fn archive_full_on_id_overflow() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("test.bale");
+
+        let mut writer = ArchiveWriter::create(&path).unwrap();
+        writer.trailer.set_next_id(u32::MAX);
+
+        let result = writer.add_entry("overflow.txt", b"data", 0o644);
+        assert!(matches!(result, Err(BaleError::ArchiveFull)));
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -77,4 +77,8 @@ pub enum BaleError {
     /// Path uses reserved prefix (`.bale`).
     #[error("reserved path: {0}")]
     ReservedPath(String),
+
+    /// Archive has exhausted its entry ID space (u32::MAX reached).
+    #[error("archive is full: entry ID space exhausted")]
+    ArchiveFull,
 }

--- a/src/format/trailer.rs
+++ b/src/format/trailer.rs
@@ -266,6 +266,7 @@ impl Trailer {
     /// - Magic bytes are `BALE` at offset 56
     /// - `alignment_power` is within valid range (≤ 16)
     /// - `path_size` is in range 1..=4096
+    /// - `next_id` is non-zero (entry IDs start at 1)
     ///
     /// Note: The `reserved` field is NOT checked. Non-zero reserved bytes are
     /// silently ignored for forward compatibility with future format extensions.
@@ -276,6 +277,7 @@ impl Trailer {
             && self.alignment_power <= Self::MAX_ALIGNMENT_POWER
             && path_size >= Self::MIN_PATH_SIZE
             && path_size <= Self::MAX_PATH_SIZE
+            && self.next_id.get() > 0
     }
 
     /// Validates the trailer and returns a reference or an error.
@@ -577,6 +579,22 @@ mod tests {
         trailer.alignment_power = Trailer::MAX_ALIGNMENT_POWER + 1;
         assert!(!trailer.is_valid());
         assert!(trailer.alignment().is_err());
+    }
+
+    /// next_id = 0 fails is_valid().
+    #[test]
+    fn next_id_zero_fails_validation() {
+        let mut trailer = Trailer::new();
+        trailer.set_next_id(0);
+        assert!(!trailer.is_valid());
+    }
+
+    /// next_id = u32::MAX passes is_valid() (archive is full but valid).
+    #[test]
+    fn next_id_max_passes_validation() {
+        let mut trailer = Trailer::new();
+        trailer.set_next_id(u32::MAX);
+        assert!(trailer.is_valid());
     }
 
     /// path_size = 0 fails is_valid().


### PR DESCRIPTION
## Summary

- Writer returns `BaleError::ArchiveFull` when `next_id` reaches `u32::MAX`
- Trailer validation rejects `next_id == 0` on open (entry IDs start at 1)

## Test plan

- [x] New test: `archive_full_on_id_overflow` — writer returns `ArchiveFull` at `u32::MAX`
- [x] New test: `next_id_zero_fails_validation` — trailer with `next_id == 0` is invalid
- [x] New test: `next_id_max_passes_validation` — `u32::MAX` is valid (full but not corrupt)
- [x] All 191 tests pass
- [x] Pre-commit hooks pass

Closes #157