### PR TITLE
Validate symlink targets at write time and read time

### DIFF
--- a/src/archive/archive_read.rs
+++ b/src/archive/archive_read.rs
@@ -4,6 +4,37 @@ use crate::archive::{DirEntry, Entry, FileEntry, SymlinkEntry};
 use crate::format::{EntryRow, Trailer};
 use crate::{ArchivePath, BaleError};
 
+/// Maximum number of symlink resolutions before declaring a loop.
+const MAX_SYMLINK_DEPTH: u32 = 256;
+
+/// Resolves a symlink target path relative to the symlink's location.
+///
+/// Joins the symlink's parent directory with the target and normalizes
+/// the result via [`ArchivePath::try_from`].
+///
+/// # Errors
+///
+/// Returns [`BaleError::InvalidPath`] if the resolved path escapes the
+/// archive root or is otherwise invalid.
+/// Returns [`BaleError::InvalidUtf8`] if the symlink path is not valid UTF-8.
+fn resolve_target(symlink_path: &ArchivePath<'_>, target: &str) -> Result<String, BaleError> {
+    // Reject absolute symlink targets (defense against malicious archives).
+    if target.starts_with('/') || target.starts_with('\\') {
+        return Err(BaleError::InvalidPath);
+    }
+
+    let parent = symlink_path.parent();
+    let joined = if parent.is_empty() {
+        target.to_string()
+    } else {
+        let parent_str = parent.to_str_checked()?;
+        format!("{parent_str}/{target}")
+    };
+    let normalized = ArchivePath::try_from(joined.as_str())?;
+    // ArchivePath::try_from(&str) always produces valid UTF-8.
+    Ok(normalized.as_str().unwrap().to_string())
+}
+
 /// Read operations for archives.
 ///
 /// This trait is implemented for all `Archive<M>` where `M` provides byte access.
@@ -160,4 +191,90 @@ pub trait ArchiveRead {
     ///
     /// Returns `None` if no entry with the given ID exists.
     fn find_by_id(&self, id: u32) -> Option<Entry<'_>>;
+
+    /// Resolves a path, following symlinks transparently.
+    ///
+    /// Implements the high-level path-walking resolution algorithm from the
+    /// spec (§ Symlink Resolution). Symlinks are followed up to a depth of
+    /// 256 before returning [`BaleError::SymlinkLoop`]. Low-level methods
+    /// ([`entry`](Self::entry), [`file`](Self::file),
+    /// [`symlink`](Self::symlink)) are unaffected.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    /// - The path is not found ([`BaleError::EntryNotFound`])
+    /// - A non-directory component is used as a directory
+    ///   ([`BaleError::NotADirectory`])
+    /// - A symlink loop is detected ([`BaleError::SymlinkLoop`])
+    /// - The path is invalid ([`BaleError::InvalidPath`])
+    fn resolve(&self, path: impl AsRef<str>) -> Result<Entry<'_>, BaleError> {
+        let normalized = ArchivePath::try_from(path.as_ref())?;
+        // ArchivePath::try_from(&str) always produces valid UTF-8.
+        let mut current_path = normalized.as_str().unwrap().to_string();
+        let mut depth = 0u32;
+
+        'outer: loop {
+            // Fast path: look up the full path.
+            match self.entry(&current_path) {
+                Ok(Entry::Symlink(symlink)) => {
+                    depth += 1;
+                    if depth > MAX_SYMLINK_DEPTH {
+                        return Err(BaleError::SymlinkLoop(current_path));
+                    }
+                    let target = symlink.target().ok_or(BaleError::InvalidPath)?;
+                    current_path = resolve_target(symlink.path(), target)?;
+                    continue;
+                }
+                Ok(entry) => return Ok(entry),
+                Err(BaleError::EntryNotFound(_)) => {}
+                Err(e) => return Err(e),
+            }
+
+            // Component walk: split path and resolve front-to-back.
+            let components: Vec<&str> = current_path.split('/').collect();
+            let mut resolved = String::new();
+
+            for (i, component) in components.iter().enumerate() {
+                if resolved.is_empty() {
+                    resolved.push_str(component);
+                } else {
+                    resolved.push('/');
+                    resolved.push_str(component);
+                }
+
+                let remaining = &components[i + 1..];
+
+                match self.entry(&resolved) {
+                    Ok(Entry::Symlink(symlink)) => {
+                        depth += 1;
+                        if depth > MAX_SYMLINK_DEPTH {
+                            return Err(BaleError::SymlinkLoop(current_path));
+                        }
+                        let target = symlink.target().ok_or(BaleError::InvalidPath)?;
+                        let resolved_target = resolve_target(symlink.path(), target)?;
+                        current_path = if remaining.is_empty() {
+                            resolved_target
+                        } else {
+                            format!("{resolved_target}/{}", remaining.join("/"))
+                        };
+                        continue 'outer;
+                    }
+                    Ok(entry) if remaining.is_empty() => return Ok(entry),
+                    Ok(Entry::File(_)) => {
+                        return Err(BaleError::NotADirectory(resolved));
+                    }
+                    Ok(Entry::Directory(_)) => {
+                        // Continue to next component.
+                    }
+                    Err(BaleError::EntryNotFound(_)) => {
+                        return Err(BaleError::EntryNotFound(current_path));
+                    }
+                    Err(e) => return Err(e),
+                }
+            }
+
+            unreachable!("component walk exhausted without returning");
+        }
+    }
 }

--- a/src/archive/archive_write.rs
+++ b/src/archive/archive_write.rs
@@ -181,7 +181,8 @@ pub trait ArchiveWrite: ArchiveRead {
     /// Creates a symbolic link entry.
     ///
     /// Symlink entries store the target path as their data block content,
-    /// with symlink mode bits set.
+    /// with symlink mode bits set. The target is validated to prevent
+    /// absolute paths and paths that escape the archive root.
     ///
     /// # Arguments
     ///
@@ -195,6 +196,8 @@ pub trait ArchiveWrite: ArchiveRead {
     /// Returns an error if:
     /// - The path exceeds the archive's path_size
     /// - Writing to the archive fails
+    /// - The target is an absolute path ([`BaleError::InvalidPath`])
+    /// - The target escapes the archive root ([`BaleError::InvalidPath`])
     fn add_symlink(
         &mut self,
         path: impl AsRef<str>,

--- a/src/archive/reader.rs
+++ b/src/archive/reader.rs
@@ -1281,4 +1281,215 @@ mod tests {
         let data = archive.read_data(entry).unwrap();
         assert_eq!(data, b"data");
     }
+
+    // ==================== resolve() Tests ====================
+
+    /// resolve() returns a non-symlink entry directly (fast path).
+    #[test]
+    fn resolve_direct_file() {
+        let bytes = build_test_archive(&[TestEntry {
+            path: "hello.txt",
+            data: b"Hello",
+            mode: 0o100644,
+            id: 1,
+        }]);
+        let archive = archive_from_bytes(&bytes);
+
+        let entry = archive.resolve("hello.txt").unwrap();
+        assert!(entry.is_file());
+        let file = entry.into_file().unwrap();
+        assert_eq!(file.data(), b"Hello");
+    }
+
+    /// resolve() follows a simple symlink to a file.
+    #[test]
+    fn resolve_simple_symlink() {
+        let bytes = build_test_archive(&[
+            TestEntry {
+                path: "link",
+                data: b"target.txt",
+                mode: 0o120777,
+                id: 1,
+            },
+            TestEntry {
+                path: "target.txt",
+                data: b"content",
+                mode: 0o100644,
+                id: 2,
+            },
+        ]);
+        let archive = archive_from_bytes(&bytes);
+
+        let entry = archive.resolve("link").unwrap();
+        assert!(entry.is_file());
+        let file = entry.into_file().unwrap();
+        assert_eq!(file.data(), b"content");
+    }
+
+    /// resolve() follows a chain of symlinks (symlink → symlink → file).
+    #[test]
+    fn resolve_symlink_chain() {
+        let bytes = build_test_archive(&[
+            TestEntry {
+                path: "a",
+                data: b"b",
+                mode: 0o120777,
+                id: 1,
+            },
+            TestEntry {
+                path: "b",
+                data: b"c",
+                mode: 0o120777,
+                id: 2,
+            },
+            TestEntry {
+                path: "c",
+                data: b"final",
+                mode: 0o100644,
+                id: 3,
+            },
+        ]);
+        let archive = archive_from_bytes(&bytes);
+
+        let entry = archive.resolve("a").unwrap();
+        assert!(entry.is_file());
+        let file = entry.into_file().unwrap();
+        assert_eq!(file.data(), b"final");
+    }
+
+    /// resolve() follows an intermediate directory symlink.
+    #[test]
+    fn resolve_intermediate_symlink() {
+        let bytes = build_test_archive(&[
+            TestEntry {
+                path: "dir",
+                data: b"",
+                mode: 0o040755,
+                id: 1,
+            },
+            TestEntry {
+                path: "dir/file.txt",
+                data: b"in dir",
+                mode: 0o100644,
+                id: 2,
+            },
+            TestEntry {
+                path: "link",
+                data: b"dir",
+                mode: 0o120777,
+                id: 3,
+            },
+        ]);
+        let archive = archive_from_bytes(&bytes);
+
+        let entry = archive.resolve("link/file.txt").unwrap();
+        assert!(entry.is_file());
+        let file = entry.into_file().unwrap();
+        assert_eq!(file.data(), b"in dir");
+    }
+
+    /// resolve() handles symlink targets containing `..`.
+    #[test]
+    fn resolve_symlink_with_dotdot() {
+        let bytes = build_test_archive(&[
+            TestEntry {
+                path: "a",
+                data: b"",
+                mode: 0o040755,
+                id: 1,
+            },
+            TestEntry {
+                path: "a/link",
+                data: b"../b/target.txt",
+                mode: 0o120777,
+                id: 2,
+            },
+            TestEntry {
+                path: "b",
+                data: b"",
+                mode: 0o040755,
+                id: 3,
+            },
+            TestEntry {
+                path: "b/target.txt",
+                data: b"found it",
+                mode: 0o100644,
+                id: 4,
+            },
+        ]);
+        let archive = archive_from_bytes(&bytes);
+
+        let entry = archive.resolve("a/link").unwrap();
+        assert!(entry.is_file());
+        let file = entry.into_file().unwrap();
+        assert_eq!(file.data(), b"found it");
+    }
+
+    /// resolve() detects circular symlinks and returns SymlinkLoop.
+    #[test]
+    fn resolve_symlink_loop() {
+        let bytes = build_test_archive(&[
+            TestEntry {
+                path: "x",
+                data: b"y",
+                mode: 0o120777,
+                id: 1,
+            },
+            TestEntry {
+                path: "y",
+                data: b"x",
+                mode: 0o120777,
+                id: 2,
+            },
+        ]);
+        let archive = archive_from_bytes(&bytes);
+
+        let result = archive.resolve("x");
+        assert!(matches!(result, Err(BaleError::SymlinkLoop(_))));
+    }
+
+    /// resolve() returns EntryNotFound for a dangling symlink.
+    #[test]
+    fn resolve_dangling_symlink() {
+        let bytes = build_test_archive(&[TestEntry {
+            path: "broken",
+            data: b"nonexistent",
+            mode: 0o120777,
+            id: 1,
+        }]);
+        let archive = archive_from_bytes(&bytes);
+
+        let result = archive.resolve("broken");
+        assert!(matches!(result, Err(BaleError::EntryNotFound(_))));
+    }
+
+    /// resolve() rejects symlinks with absolute targets in malicious archives.
+    #[test]
+    fn resolve_absolute_symlink_target() {
+        let bytes = build_test_archive(&[TestEntry {
+            path: "link",
+            data: b"/usr/share/data.txt",
+            mode: 0o120777,
+            id: 1,
+        }]);
+        let archive = archive_from_bytes(&bytes);
+
+        let result = archive.resolve("link");
+        assert!(matches!(result, Err(BaleError::InvalidPath)));
+    }
+
+    /// resolve() returns NotADirectory when a file is used as a directory.
+    #[test]
+    fn resolve_file_as_directory() {
+        let bytes = build_test_archive(&[TestEntry {
+            path: "file.txt",
+            data: b"data",
+            mode: 0o100644,
+            id: 1,
+        }]);
+        let archive = archive_from_bytes(&bytes);
+
+        let result = archive.resolve("file.txt/child");
+        assert!(matches!(result, Err(BaleError::NotADirectory(_))));
+    }
 }

--- a/src/archive/writer.rs
+++ b/src/archive/writer.rs
@@ -986,9 +986,16 @@ impl ArchiveWrite for Archive<MappedArchiveMut> {
 
     /// Creates a symlink entry.
     ///
+    /// The target is validated to prevent absolute paths and paths that
+    /// escape the archive root when resolved against the symlink's parent
+    /// directory.
+    ///
     /// # Errors
     ///
-    /// Returns an error if the path is invalid or writing fails.
+    /// Returns an error if:
+    /// - The path is invalid or writing fails
+    /// - The target is absolute (`InvalidPath`)
+    /// - The target escapes the archive root (`InvalidPath`)
     fn add_symlink(
         &mut self,
         path: impl AsRef<str>,
@@ -997,6 +1004,24 @@ impl ArchiveWrite for Archive<MappedArchiveMut> {
     ) -> Result<(), BaleError> {
         let path = path.as_ref();
         let target = target.as_ref();
+
+        // Reject absolute symlink targets.
+        if target.starts_with('/') || target.starts_with('\\') {
+            return Err(BaleError::InvalidPath);
+        }
+
+        // Reject targets that escape the archive root when resolved
+        // against the symlink's parent directory.
+        let symlink_path = ArchivePath::try_from(path)?;
+        let parent = symlink_path.parent();
+        let joined = if parent.is_empty() {
+            target.to_string()
+        } else {
+            let parent_str = parent.to_str_checked()?;
+            format!("{parent_str}/{target}")
+        };
+        ArchivePath::try_from(joined.as_str())?;
+
         // Ensure symlink type bits are set.
         let mode = if mode & SFlag::S_IFMT.bits() == 0 {
             mode | SFlag::S_IFLNK.bits()
@@ -1583,6 +1608,46 @@ mod tests {
         assert_eq!(file.data, b"new data!");
         assert_eq!(file.entry.mode.get(), 0o100755);
         reader.verify_crc(file.entry).unwrap();
+    }
+
+    /// add_symlink rejects absolute targets starting with `/`.
+    #[test]
+    fn add_symlink_rejects_absolute_target() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("test.bale");
+
+        let mut writer = ArchiveWriter::create(&path).unwrap();
+        let result = writer.add_symlink("link", "/usr/share/data.txt", 0o777);
+        assert!(matches!(result, Err(BaleError::InvalidPath)));
+    }
+
+    /// add_symlink rejects targets that escape the archive root via `..`.
+    #[test]
+    fn add_symlink_rejects_escaping_target() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("test.bale");
+
+        let mut writer = ArchiveWriter::create(&path).unwrap();
+        let result = writer.add_symlink("link", "../../outside.txt", 0o777);
+        assert!(matches!(result, Err(BaleError::InvalidPath)));
+    }
+
+    /// add_symlink allows relative targets that stay within the archive.
+    #[test]
+    fn add_symlink_allows_relative_target() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("test.bale");
+
+        {
+            let mut writer = ArchiveWriter::create(&path).unwrap();
+            // dir/link -> ../sibling resolves to "sibling", which is valid.
+            writer.add_symlink("dir/link", "../sibling", 0o777).unwrap();
+            writer.sync().unwrap();
+        }
+
+        let reader = ArchiveReader::open(&path).unwrap();
+        let symlink = reader.symlink("dir/link").unwrap();
+        assert_eq!(symlink.target(), Some("../sibling"));
     }
 
     /// replace_content on a directory returns an error.

--- a/src/archive_path.rs
+++ b/src/archive_path.rs
@@ -116,6 +116,18 @@ impl<'a> ArchivePath<'a> {
         Ok(std::str::from_utf8(&self.0)?)
     }
 
+    /// Returns the parent directory path, or an empty path for top-level entries.
+    ///
+    /// For a path like `foo/bar/baz.txt`, returns `foo/bar`.
+    /// For a top-level path like `file.txt`, returns an empty path.
+    #[must_use]
+    pub fn parent(&self) -> ArchivePath<'_> {
+        match self.0.iter().rposition(|&b| b == b'/') {
+            Some(pos) => ArchivePath(Cow::Borrowed(&self.0[..pos])),
+            None => ArchivePath(Cow::Borrowed(&[])),
+        }
+    }
+
     /// Returns the filename component as bytes (after the last `/`).
     ///
     /// For a path like `foo/bar/baz.txt`, returns `baz.txt`.
@@ -804,6 +816,32 @@ mod tests {
         let path = ArchivePath::from_bytes(b"foo\\bar");
         let normalized = path.normalize().unwrap();
         assert_eq!(normalized.as_str(), Some("foo/bar"));
+    }
+
+    // ==================== Parent Tests ====================
+
+    /// parent() of a top-level path returns an empty path.
+    #[test]
+    fn parent_top_level() {
+        let path = ArchivePath::try_from("file.txt").unwrap();
+        let parent = path.parent();
+        assert!(parent.is_empty());
+    }
+
+    /// parent() of a nested path returns the parent directory.
+    #[test]
+    fn parent_nested() {
+        let path = ArchivePath::try_from("foo/bar.txt").unwrap();
+        let parent = path.parent();
+        assert_eq!(parent.as_str(), Some("foo"));
+    }
+
+    /// parent() of a deeply nested path returns the full parent.
+    #[test]
+    fn parent_deeply_nested() {
+        let path = ArchivePath::try_from("a/b/c/d.txt").unwrap();
+        let parent = path.parent();
+        assert_eq!(parent.as_str(), Some("a/b/c"));
     }
 
     // ==================== Safename Tests ====================

--- a/src/error.rs
+++ b/src/error.rs
@@ -82,6 +82,10 @@ pub enum BaleError {
     #[error("path already exists: {0}")]
     PathExists(String),
 
+    /// Symlink resolution exceeded the maximum depth (cycle detected).
+    #[error("symlink loop: {0}")]
+    SymlinkLoop(String),
+
     /// Archive has exhausted its entry ID space (u32::MAX reached).
     #[error("archive is full: entry ID space exhausted")]
     ArchiveFull,


### PR DESCRIPTION
## Summary
- Reject absolute and root-escaping symlink targets at write time in `add_symlink()`
- Reject absolute symlink targets at read time in `resolve_target()` as defense against malicious archives
- Add `resolve()` method for transparent symlink following with loop detection (max depth 256)
- Add `ArchivePath::parent()` helper and `SymlinkLoop` error variant

## Test plan
- [x] `add_symlink_rejects_absolute_target` — absolute target returns `InvalidPath`
- [x] `add_symlink_rejects_escaping_target` — `../../outside.txt` returns `InvalidPath`
- [x] `add_symlink_allows_relative_target` — `../sibling` from `dir/link` succeeds
- [x] `resolve_absolute_symlink_target` — absolute target in crafted archive returns `InvalidPath`
- [x] All 224 tests pass, clippy clean, fmt clean