### PR TITLE
Return FileLocked error instead of blocking when archive is locked

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -89,4 +89,8 @@ pub enum BaleError {
     /// Archive has exhausted its entry ID space (u32::MAX reached).
     #[error("archive is full: entry ID space exhausted")]
     ArchiveFull,
+
+    /// The archive file is locked by another process.
+    #[error("file is locked by another process")]
+    FileLocked,
 }

--- a/src/mmap/mapped_archive.rs
+++ b/src/mmap/mapped_archive.rs
@@ -40,7 +40,10 @@ impl MappedArchive {
     /// cooperative writers from modifying it during the mapping lifetime.
     pub fn open(path: impl AsRef<Path>) -> Result<Self, BaleError> {
         let file = File::open(path.as_ref())?;
-        file.lock_shared()?;
+        file.try_lock_shared().map_err(|e| match e {
+            std::fs::TryLockError::WouldBlock => BaleError::FileLocked,
+            std::fs::TryLockError::Error(io_err) => BaleError::Io(io_err),
+        })?;
         // SAFETY: We hold a shared lock on the file, preventing cooperative
         // writers from modifying it while mapped.
         #[allow(unsafe_code)]
@@ -103,5 +106,15 @@ mod tests {
         let mapped = MappedArchive::open(file.path()).unwrap();
         assert!(mapped.is_empty());
         assert_eq!(mapped.len(), 0);
+    }
+
+    /// Opening a file that is exclusively locked returns `FileLocked`.
+    #[test]
+    fn open_while_exclusively_locked() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("locked.bale");
+        let _writer = crate::MappedArchiveMut::create(&path).unwrap();
+        let result = MappedArchive::open(&path);
+        assert!(matches!(result, Err(BaleError::FileLocked)));
     }
 }

--- a/src/mmap/mapped_archive_mut.rs
+++ b/src/mmap/mapped_archive_mut.rs
@@ -1,7 +1,6 @@
 //! Read-write memory-mapped archive.
 
 use crate::BaleError;
-use fs4::fs_std::FileExt;
 use std::fs::File;
 use std::path::Path;
 
@@ -83,7 +82,10 @@ impl MappedArchiveMut {
             .write(true)
             .create_new(true)
             .open(path.as_ref())?;
-        file.lock_exclusive()?;
+        file.try_lock().map_err(|e| match e {
+            std::fs::TryLockError::WouldBlock => BaleError::FileLocked,
+            std::fs::TryLockError::Error(io_err) => BaleError::Io(io_err),
+        })?;
         file.set_len(capacity as u64)?;
         // SAFETY: We hold an exclusive lock on the file.
         #[allow(unsafe_code)]
@@ -115,7 +117,10 @@ impl MappedArchiveMut {
             .read(true)
             .write(true)
             .open(path.as_ref())?;
-        file.lock_exclusive()?;
+        file.try_lock().map_err(|e| match e {
+            std::fs::TryLockError::WouldBlock => BaleError::FileLocked,
+            std::fs::TryLockError::Error(io_err) => BaleError::Io(io_err),
+        })?;
         let len = file.metadata()?.len() as usize;
         // SAFETY: We hold an exclusive lock on the file.
         #[allow(unsafe_code)]
@@ -355,5 +360,16 @@ mod tests {
         // Re-open and verify size.
         let metadata = std::fs::metadata(&path).unwrap();
         assert_eq!(metadata.len(), 9);
+    }
+
+    /// Opening a file that is exclusively locked returns `FileLocked`.
+    #[test]
+    fn open_while_exclusively_locked() {
+        let mut file = NamedTempFile::new().unwrap();
+        file.write_all(b"test data").unwrap();
+        file.flush().unwrap();
+        let _first = MappedArchiveMut::open(file.path()).unwrap();
+        let result = MappedArchiveMut::open(file.path());
+        assert!(matches!(result, Err(BaleError::FileLocked)));
     }
 }


### PR DESCRIPTION
## Summary

Closes #166.

- Replace blocking `lock_shared()` / `lock_exclusive()` calls with non-blocking `try_lock_shared()` / `try_lock()` from the std library
- Add `BaleError::FileLocked` variant returned when `TryLockError::WouldBlock` is encountered
- Remove the now-unused `fs4::fs_std::FileExt` import from `mapped_archive_mut.rs`

## Test plan

- [x] `mapped_archive::tests::open_while_exclusively_locked` — reader returns `FileLocked` when writer holds exclusive lock
- [x] `mapped_archive_mut::tests::open_while_exclusively_locked` — second writer returns `FileLocked` when first writer holds exclusive lock
- [x] All 226 existing tests pass
- [x] Clippy and fmt checks pass