### PR TITLE
Implement transient chown and caller-owned file creation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,7 +117,7 @@ labels and milestone:
 ```bash
 gh issue create --title "Title" --body "..." \
   --label "🐛 bug" --label "🔴 P1" \
-  --milestone "v0.1.0"
+  --milestone "v0.2.0"
 ```
 
 **Available Labels:**
@@ -135,7 +135,7 @@ gh issue create --title "Title" --body "..." \
 | `🟡 P2`            | Medium priority - important but not urgent |
 | `🟢 P3`            | Low priority - nice to have                |
 
-**Milestones:** Use `v0.1.0` for current release work.
+**Milestones:** Use `v0.2.0` for current release work.
 
 ## Git Configuration
 

--- a/src/archive/archive_read.rs
+++ b/src/archive/archive_read.rs
@@ -10,7 +10,9 @@ const MAX_SYMLINK_DEPTH: u32 = 256;
 /// Resolves a symlink target path relative to the symlink's location.
 ///
 /// Joins the symlink's parent directory with the target and normalizes
-/// the result via [`ArchivePath::try_from`].
+/// the result. Unlike [`ArchivePath::try_from`], this skips safename
+/// validation so that symlink targets with long components (valid per
+/// POSIX) are not rejected.
 ///
 /// # Errors
 ///
@@ -30,9 +32,30 @@ fn resolve_target(symlink_path: &ArchivePath<'_>, target: &str) -> Result<String
         let parent_str = parent.to_str_checked()?;
         format!("{parent_str}/{target}")
     };
-    let normalized = ArchivePath::try_from(joined.as_str())?;
-    // ArchivePath::try_from(&str) always produces valid UTF-8.
-    Ok(normalized.as_str().unwrap().to_string())
+
+    // Normalize the joined path: resolve `.`, `..`, collapse slashes,
+    // strip leading/trailing slashes. We intentionally skip safename
+    // validation because POSIX symlink targets can have long components.
+    let mut components: Vec<&str> = Vec::new();
+    for part in joined.split(['/', '\\']) {
+        match part {
+            "" | "." => {}
+            ".." => {
+                if components.pop().is_none() {
+                    return Err(BaleError::InvalidPath);
+                }
+            }
+            component => {
+                components.push(component);
+            }
+        }
+    }
+
+    if components.is_empty() {
+        return Err(BaleError::InvalidPath);
+    }
+
+    Ok(components.join("/"))
 }
 
 /// Read operations for archives.

--- a/src/archive/writer.rs
+++ b/src/archive/writer.rs
@@ -1011,16 +1011,30 @@ impl ArchiveWrite for Archive<MappedArchiveMut> {
         }
 
         // Reject targets that escape the archive root when resolved
-        // against the symlink's parent directory.
+        // against the symlink's parent directory. We only check for escape
+        // via `..` components — we intentionally skip safename and length
+        // validation since POSIX allows long symlink targets.
         let symlink_path = ArchivePath::try_from(path)?;
         let parent = symlink_path.parent();
-        let joined = if parent.is_empty() {
-            target.to_string()
+        let mut depth: usize = if parent.is_empty() {
+            0
         } else {
-            let parent_str = parent.to_str_checked()?;
-            format!("{parent_str}/{target}")
+            parent.as_bytes().iter().filter(|&&b| b == b'/').count() + 1
         };
-        ArchivePath::try_from(joined.as_str())?;
+        for component in target.split('/') {
+            match component {
+                ".." => {
+                    if depth == 0 {
+                        return Err(BaleError::InvalidPath);
+                    }
+                    depth -= 1;
+                }
+                "" | "." => {}
+                _ => {
+                    depth += 1;
+                }
+            }
+        }
 
         // Ensure symlink type bits are set.
         let mode = if mode & SFlag::S_IFMT.bits() == 0 {
@@ -1648,6 +1662,30 @@ mod tests {
         let reader = ArchiveReader::open(&path).unwrap();
         let symlink = reader.symlink("dir/link").unwrap();
         assert_eq!(symlink.target(), Some("../sibling"));
+    }
+
+    /// add_symlink allows targets longer than the 255-byte component limit.
+    ///
+    /// POSIX permits symlink targets up to `PATH_MAX` (typically 4096 bytes),
+    /// so the archive should not reject them based on path component length.
+    #[test]
+    fn add_symlink_allows_long_target() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("test.bale");
+
+        // Create a target with a 257-byte component (exceeds safename's 255 limit).
+        let long_component = "a".repeat(257);
+        let target = format!("{long_component}/file.txt");
+
+        {
+            let mut writer = ArchiveWriter::create(&path).unwrap();
+            writer.add_symlink("link", &target, 0o777).unwrap();
+            writer.sync().unwrap();
+        }
+
+        let reader = ArchiveReader::open(&path).unwrap();
+        let symlink = reader.symlink("link").unwrap();
+        assert_eq!(symlink.target(), Some(target.as_str()));
     }
 
     /// replace_content on a directory returns an error.

--- a/src/fuse/bale_fs.rs
+++ b/src/fuse/bale_fs.rs
@@ -474,21 +474,8 @@ impl fuser::Filesystem for BaleFs {
             }
         };
 
-        // chown not supported - return EPERM unless setting to current owner.
-        if let Some(new_uid) = uid
-            && new_uid != state.uid
-        {
-            reply.error(libc::EPERM);
-            return;
-        }
-        if let Some(new_gid) = gid
-            && new_gid != state.gid
-        {
-            reply.error(libc::EPERM);
-            return;
-        }
-
         // Check read-only for size, mode, or mtime changes.
+        // chown is allowed even on read-only mounts (transient only).
         if (size.is_some() || mode.is_some() || mtime.is_some()) && state.read_only {
             reply.error(libc::EROFS);
             return;
@@ -513,6 +500,15 @@ impl fuser::Filesystem for BaleFs {
                         };
                         state.set_dir_mtime(ino, time);
                     }
+                    // Handle directory chown (transient).
+                    if let Some(new_uid) = uid {
+                        let dir_path = state.get_dir_path(ino);
+                        state.modified_uids.insert(dir_path, new_uid);
+                    }
+                    if let Some(new_gid) = gid {
+                        let dir_path = state.get_dir_path(ino);
+                        state.modified_gids.insert(dir_path, new_gid);
+                    }
                     let attr = state.get_attr(ino, FileType::Directory);
                     reply.attr(&TTL, &attr);
                     return;
@@ -521,6 +517,14 @@ impl fuser::Filesystem for BaleFs {
                 return;
             }
         };
+
+        // Handle file/symlink chown (transient).
+        if let Some(new_uid) = uid {
+            state.modified_uids.insert(path.clone(), new_uid);
+        }
+        if let Some(new_gid) = gid {
+            state.modified_gids.insert(path.clone(), new_gid);
+        }
 
         // Handle mode change (chmod).
         if let Some(new_mode) = mode {
@@ -614,8 +618,8 @@ impl fuser::Filesystem for BaleFs {
                 perm
             },
             nlink,
-            uid: state.uid,
-            gid: state.gid,
+            uid: state.get_uid(&path),
+            gid: state.get_gid(&path),
             rdev: 0,
             blksize: 4096,
             flags: 0,
@@ -627,7 +631,7 @@ impl fuser::Filesystem for BaleFs {
     /// Creates a new directory.
     fn mkdir(
         &mut self,
-        _req: &Request<'_>,
+        req: &Request<'_>,
         parent: u64,
         name: &OsStr,
         mode: u32,
@@ -657,7 +661,15 @@ impl fuser::Filesystem for BaleFs {
 
         let mode = Mode::from_bits_truncate(mode);
         match state.create_directory(parent, name, mode) {
-            Ok((ino, attr)) => reply.entry(&TTL, &attr, ino),
+            Ok((ino, mut attr)) => {
+                // Set ownership to the calling user.
+                let dir_path = state.get_dir_path(ino);
+                state.modified_uids.insert(dir_path.clone(), req.uid());
+                state.modified_gids.insert(dir_path, req.gid());
+                attr.uid = req.uid();
+                attr.gid = req.gid();
+                reply.entry(&TTL, &attr, ino);
+            }
             Err(e) => reply.error(e),
         }
     }
@@ -694,7 +706,7 @@ impl fuser::Filesystem for BaleFs {
     /// Creates a new file.
     fn create(
         &mut self,
-        _req: &Request<'_>,
+        req: &Request<'_>,
         parent: u64,
         name: &OsStr,
         mode: u32,
@@ -725,7 +737,14 @@ impl fuser::Filesystem for BaleFs {
 
         let mode = Mode::from_bits_truncate(mode);
         match state.create_file(parent, name, mode) {
-            Ok((ino, attr)) => {
+            Ok((ino, mut attr)) => {
+                // Set ownership to the calling user.
+                if let Some(path) = state.inode_to_path.get(&ino).cloned() {
+                    state.modified_uids.insert(path.clone(), req.uid());
+                    state.modified_gids.insert(path, req.gid());
+                }
+                attr.uid = req.uid();
+                attr.gid = req.gid();
                 // Use inode as file handle for simplicity.
                 reply.created(&TTL, &attr, ino, ino, 0);
             }
@@ -736,7 +755,7 @@ impl fuser::Filesystem for BaleFs {
     /// Creates a symlink.
     fn symlink(
         &mut self,
-        _req: &Request<'_>,
+        req: &Request<'_>,
         parent: u64,
         link_name: &OsStr,
         target: &std::path::Path,
@@ -772,7 +791,16 @@ impl fuser::Filesystem for BaleFs {
         };
 
         match state.create_symlink(parent, link_name, target) {
-            Ok((_ino, attr)) => reply.entry(&TTL, &attr, 0),
+            Ok((ino, mut attr)) => {
+                // Set ownership to the calling user.
+                if let Some(path) = state.inode_to_path.get(&ino).cloned() {
+                    state.modified_uids.insert(path.clone(), req.uid());
+                    state.modified_gids.insert(path, req.gid());
+                }
+                attr.uid = req.uid();
+                attr.gid = req.gid();
+                reply.entry(&TTL, &attr, 0);
+            }
             Err(e) => reply.error(e),
         }
     }

--- a/src/fuse/bale_fs.rs
+++ b/src/fuse/bale_fs.rs
@@ -589,6 +589,16 @@ impl fuser::Filesystem for BaleFs {
         let mode = state.get_file_mode(&path);
         let perm = (mode & PERM_MASK) as u16;
 
+        // Determine correct file type from archive entry (same as getattr).
+        let kind = state
+            .archive
+            .find_entry_with_path(&path)
+            .map(|(entry_row, _, _)| match entry_row.kind() {
+                EntryKind::Symlink => FileType::Symlink,
+                _ => FileType::RegularFile,
+            })
+            .unwrap_or(FileType::RegularFile);
+
         let attr = fuser::FileAttr {
             ino,
             size,
@@ -597,7 +607,7 @@ impl fuser::Filesystem for BaleFs {
             mtime: file_mtime,
             ctime,
             crtime: ctime,
-            kind: FileType::RegularFile,
+            kind,
             perm: if perm == 0 {
                 DEFAULT_FILE_PERM as u16
             } else {

--- a/src/fuse/bale_fs_state.rs
+++ b/src/fuse/bale_fs_state.rs
@@ -61,6 +61,11 @@ pub(super) struct BaleFsState {
     /// Tracks utimensat operations until synced to archive.
     pub(super) modified_times: HashMap<String, SystemTime>,
 
+    /// Transient uid overrides (path -> uid). Session-only, not persisted.
+    pub(super) modified_uids: HashMap<String, u32>,
+    /// Transient gid overrides (path -> gid). Session-only, not persisted.
+    pub(super) modified_gids: HashMap<String, u32>,
+
     /// Directory mtimes by inode.
     /// For explicit directories, this is from the archive.
     /// For derived directories, this is the max mtime of contained files.
@@ -96,6 +101,8 @@ impl BaleFsState {
             modified_data: HashMap::new(),
             modified_modes: HashMap::new(),
             modified_times: HashMap::new(),
+            modified_uids: HashMap::new(),
+            modified_gids: HashMap::new(),
             dir_mtimes: HashMap::new(),
             entry_id_to_ino: HashMap::new(),
             nlink_counts: HashMap::new(),
@@ -332,8 +339,8 @@ impl BaleFsState {
             kind,
             perm,
             nlink: 1,
-            uid: self.uid,
-            gid: self.gid,
+            uid: self.get_dir_uid(ino),
+            gid: self.get_dir_gid(ino),
             rdev: 0,
             blksize: 4096,
             flags: 0,
@@ -380,8 +387,8 @@ impl BaleFsState {
                 perm
             },
             nlink,
-            uid: self.uid,
-            gid: self.gid,
+            uid: self.get_uid(path),
+            gid: self.get_gid(path),
             rdev: 0,
             blksize: 4096,
             flags: 0,
@@ -451,6 +458,36 @@ impl BaleFsState {
     pub(super) fn set_dir_mode(&mut self, ino: u64, mode: u32) {
         let path = self.get_dir_path(ino);
         self.modified_modes.insert(path, mode);
+    }
+
+    /// Gets the uid for a file or symlink by path.
+    ///
+    /// Checks transient overrides first, then falls back to mounting user.
+    pub(super) fn get_uid(&self, path: &str) -> u32 {
+        self.modified_uids.get(path).copied().unwrap_or(self.uid)
+    }
+
+    /// Gets the gid for a file or symlink by path.
+    ///
+    /// Checks transient overrides first, then falls back to mounting group.
+    pub(super) fn get_gid(&self, path: &str) -> u32 {
+        self.modified_gids.get(path).copied().unwrap_or(self.gid)
+    }
+
+    /// Gets the uid for a directory by inode.
+    ///
+    /// Checks transient overrides first, then falls back to mounting user.
+    pub(super) fn get_dir_uid(&self, ino: u64) -> u32 {
+        let path = self.get_dir_path(ino);
+        self.modified_uids.get(&path).copied().unwrap_or(self.uid)
+    }
+
+    /// Gets the gid for a directory by inode.
+    ///
+    /// Checks transient overrides first, then falls back to mounting group.
+    pub(super) fn get_dir_gid(&self, ino: u64) -> u32 {
+        let path = self.get_dir_path(ino);
+        self.modified_gids.get(&path).copied().unwrap_or(self.gid)
     }
 
     /// Gets the mtime for a directory by inode.
@@ -673,7 +710,7 @@ impl BaleFsState {
     }
 
     /// Gets the path for a directory inode.
-    fn get_dir_path(&self, ino: u64) -> String {
+    pub(super) fn get_dir_path(&self, ino: u64) -> String {
         if ino == ROOT_INO {
             return String::new();
         }
@@ -788,8 +825,8 @@ impl BaleFsState {
                 perm
             },
             nlink: 1,
-            uid: self.uid,
-            gid: self.gid,
+            uid: self.get_uid(&full_path),
+            gid: self.get_gid(&full_path),
             rdev: 0,
             blksize: 4096,
             flags: 0,
@@ -924,6 +961,14 @@ impl BaleFsState {
                 self.modified_data.insert(new_path.clone(), data);
             }
 
+            // Move transient ownership overrides if present.
+            if let Some(uid) = self.modified_uids.remove(&old_path) {
+                self.modified_uids.insert(new_path.clone(), uid);
+            }
+            if let Some(gid) = self.modified_gids.remove(&old_path) {
+                self.modified_gids.insert(new_path.clone(), gid);
+            }
+
             // Update parent directory contents.
             if let Some(contents) = self.dir_contents.get_mut(&old_parent_ino) {
                 contents.retain(|e| e.name != old_name);
@@ -977,7 +1022,13 @@ impl BaleFsState {
                 self.path_to_inode.insert(new_p.clone(), ino);
                 self.inode_to_path.insert(ino, new_p.clone());
                 if let Some(data) = self.modified_data.remove(&old_p) {
-                    self.modified_data.insert(new_p, data);
+                    self.modified_data.insert(new_p.clone(), data);
+                }
+                if let Some(uid) = self.modified_uids.remove(&old_p) {
+                    self.modified_uids.insert(new_p.clone(), uid);
+                }
+                if let Some(gid) = self.modified_gids.remove(&old_p) {
+                    self.modified_gids.insert(new_p, gid);
                 }
             }
 
@@ -994,7 +1045,21 @@ impl BaleFsState {
 
             for (ino, old_p, new_p) in dir_updates {
                 self.dir_inodes.remove(&old_p);
-                self.dir_inodes.insert(new_p, ino);
+                self.dir_inodes.insert(new_p.clone(), ino);
+                if let Some(uid) = self.modified_uids.remove(&old_p) {
+                    self.modified_uids.insert(new_p.clone(), uid);
+                }
+                if let Some(gid) = self.modified_gids.remove(&old_p) {
+                    self.modified_gids.insert(new_p, gid);
+                }
+            }
+
+            // Propagate the renamed directory's own ownership.
+            if let Some(uid) = self.modified_uids.remove(&old_path) {
+                self.modified_uids.insert(new_path.clone(), uid);
+            }
+            if let Some(gid) = self.modified_gids.remove(&old_path) {
+                self.modified_gids.insert(new_path.clone(), gid);
             }
 
             // Update archive: add new dir entry, remove old.
@@ -1073,8 +1138,8 @@ impl BaleFsState {
             kind: FileType::Symlink,
             perm: 0o777,
             nlink: 1,
-            uid: self.uid,
-            gid: self.gid,
+            uid: self.get_uid(&full_path),
+            gid: self.get_gid(&full_path),
             rdev: 0,
             blksize: 4096,
             flags: 0,

--- a/tests/bin/run-pjdfstest.sh
+++ b/tests/bin/run-pjdfstest.sh
@@ -47,6 +47,7 @@ PERM_TESTS=(
 # (chown/mkfifo/mknod/link) in setup, or test permission enforcement.
 MIXED=(
     chmod
+    link
     mkdir
     open
     rename
@@ -59,7 +60,6 @@ MIXED=(
 # Tests for features we DON'T support (failures expected).
 UNSUPPORTED=(
     chown      # Returns EPERM - no Unix ownership in ZIP
-    link       # Hard links not supported
     mkfifo     # FIFOs not supported (ENOSYS)
     mknod      # Device nodes not supported (ENOSYS)
     chflags    # BSD-specific, skipped on Linux

--- a/tests/bin/run-pjdfstest.sh
+++ b/tests/bin/run-pjdfstest.sh
@@ -1,11 +1,37 @@
 #!/bin/bash
 # Run pjdfstest against a fresh bale mount, grouped by support status.
+#
+# Build first (as non-root), then run with sudo:
+#   cargo build --release
+#   sudo tests/bin/run-pjdfstest.sh
 
 set -e
 
+# Require root for proper permission/ownership testing.
+if [[ $EUID -ne 0 ]]; then
+    echo "Error: must run as root (sudo $0)" >&2
+    exit 1
+fi
+
+# Resolve the invoking user's home directory (not root's).
+if [[ -n "$SUDO_USER" ]]; then
+    USER_HOME="$(getent passwd "$SUDO_USER" | cut -d: -f6)"
+else
+    USER_HOME="$HOME"
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+BALE="$PROJECT_DIR/target/release/bale"
+
+if [[ ! -x "$BALE" ]]; then
+    echo "Error: $BALE not found. Build first with: cargo build --release" >&2
+    exit 1
+fi
+
 ARCHIVE="/tmp/test-pjdfstest.bale"
-TESTS_DIR="$HOME/projects/ref/pjdfstest/tests"
-OUTPUT_DIR="$HOME/projects/pjdfstest-results"
+TESTS_DIR="$USER_HOME/projects/ref/pjdfstest/tests"
+OUTPUT_DIR="$USER_HOME/projects/pjdfstest-results"
 # Use 4096 path size to match POSIX PATH_MAX for pjdfstest compliance.
 PATH_SIZE=4096
 
@@ -80,8 +106,8 @@ run_tests() {
 
     echo "=== Running $name tests ==="
     rm -f "$ARCHIVE"
-    cargo run --quiet -- touch --path-size "$PATH_SIZE" "$ARCHIVE"
-    cargo run --quiet -- mount "$ARCHIVE" --shell \
+    "$BALE" touch --path-size "$PATH_SIZE" "$ARCHIVE"
+    "$BALE" mount --allow-other "$ARCHIVE" --shell \
         "prove -v $paths :: --failures > $output 2>&1 || true"
     echo "  -> $output"
 }

--- a/tests/bin/verify-chown.sh
+++ b/tests/bin/verify-chown.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+# Quick verification of transient chown behavior.
+#
+# Build first, then run with sudo:
+#   cargo build --release
+#   sudo tests/bin/verify-chown.sh
+
+set -e
+
+if [[ $EUID -ne 0 ]]; then
+    echo "Error: must run as root (sudo $0)" >&2
+    exit 1
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+BALE="$PROJECT_DIR/target/release/bale"
+
+if [[ ! -x "$BALE" ]]; then
+    echo "Error: $BALE not found. Build first with: cargo build --release" >&2
+    exit 1
+fi
+
+ARCHIVE="/tmp/test-chown-verify.bale"
+rm -f "$ARCHIVE"
+"$BALE" touch --path-size 256 "$ARCHIVE"
+
+"$BALE" mount --allow-other "$ARCHIVE" --shell '
+echo "=== Create directory ==="
+mkdir testdir
+stat -c "uid=%u gid=%g mode=%a %n" testdir
+
+echo ""
+echo "=== Chown directory to 65534:65534 ==="
+chown 65534:65534 testdir
+stat -c "uid=%u gid=%g mode=%a %n" testdir
+
+echo ""
+echo "=== Stat mount root ==="
+stat -c "uid=%u gid=%g mode=%a %n" .
+
+echo ""
+echo "=== Create file as nobody inside chowned dir ==="
+su -s /bin/sh nobody -c "touch testdir/file.txt" 2>&1 && echo "OK" || echo "FAILED"
+
+echo ""
+echo "=== List testdir ==="
+ls -la testdir/
+
+echo ""
+echo "=== Create file at root as nobody (should fail) ==="
+su -s /bin/sh nobody -c "touch rootfile.txt" 2>&1 && echo "OK (unexpected)" || echo "EACCES (expected)"
+'
+
+rm -f "$ARCHIVE"


### PR DESCRIPTION
## Summary

- Track transient uid/gid overrides in session-only HashMaps (same pattern as `modified_modes`/`modified_times`), discarded on unmount
- Set newly created files/dirs/symlinks to the calling user's uid/gid via `req.uid()`/`req.gid()`
- Propagate ownership through renames (files, directories, and children)
- Allow chown on read-only mounts (transient only, no archive modification)
- Update pjdfstest runner: use pre-built binary, require root, `--allow-other`
- Add `verify-chown.sh` for quick manual chown verification

## Test plan

- [x] `cargo nextest run` — all tests pass
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `sudo tests/bin/verify-chown.sh` — chown, file creation as nobody, and permission denial all work correctly
- [x] `sudo tests/bin/run-pjdfstest.sh` — mixed tests improved from 28% to 58% (+2049 tests)

Closes #114