### PR TITLE
Validate symlink target components with safename rules

### DIFF
--- a/src/archive/archive_read.rs
+++ b/src/archive/archive_read.rs
@@ -10,16 +10,21 @@ const MAX_SYMLINK_DEPTH: u32 = 256;
 /// Resolves a symlink target path relative to the symlink's location.
 ///
 /// Joins the symlink's parent directory with the target and normalizes
-/// the result. Unlike [`ArchivePath::try_from`], this skips safename
-/// validation so that symlink targets with long components (valid per
-/// POSIX) are not rejected.
+/// the result. Each path component is validated with
+/// [`safename::validate_file`] to reject control characters, leading
+/// dashes, and components exceeding `NAME_MAX` (255 bytes).
 ///
 /// # Errors
 ///
 /// Returns [`BaleError::InvalidPath`] if the resolved path escapes the
 /// archive root or is otherwise invalid.
+/// Returns [`BaleError::UnsafeFilename`] if any component violates safename
+/// rules.
 /// Returns [`BaleError::InvalidUtf8`] if the symlink path is not valid UTF-8.
-fn resolve_target(symlink_path: &ArchivePath<'_>, target: &str) -> Result<String, BaleError> {
+pub(crate) fn resolve_target(
+    symlink_path: &ArchivePath<'_>,
+    target: &str,
+) -> Result<String, BaleError> {
     // Reject absolute symlink targets (defense against malicious archives).
     if target.starts_with('/') || target.starts_with('\\') {
         return Err(BaleError::InvalidPath);
@@ -34,8 +39,9 @@ fn resolve_target(symlink_path: &ArchivePath<'_>, target: &str) -> Result<String
     };
 
     // Normalize the joined path: resolve `.`, `..`, collapse slashes,
-    // strip leading/trailing slashes. We intentionally skip safename
-    // validation because POSIX symlink targets can have long components.
+    // strip leading/trailing slashes. Each normal component is validated
+    // with safename to reject control chars, leading dashes, and
+    // components exceeding NAME_MAX (255 bytes).
     let mut components: Vec<&str> = Vec::new();
     for part in joined.split(['/', '\\']) {
         match part {
@@ -46,6 +52,7 @@ fn resolve_target(symlink_path: &ArchivePath<'_>, target: &str) -> Result<String
                 }
             }
             component => {
+                safename::validate_file(component)?;
                 components.push(component);
             }
         }
@@ -299,5 +306,52 @@ pub trait ArchiveRead {
 
             unreachable!("component walk exhausted without returning");
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// resolve_target rejects targets containing control characters.
+    #[test]
+    fn resolve_target_rejects_control_chars() {
+        let symlink = ArchivePath::try_from("link").unwrap();
+        let result = resolve_target(&symlink, "foo\x01bar");
+        assert!(matches!(result, Err(BaleError::UnsafeFilename(_))));
+    }
+
+    /// resolve_target rejects targets with a leading-dash component.
+    #[test]
+    fn resolve_target_rejects_leading_dash() {
+        let symlink = ArchivePath::try_from("link").unwrap();
+        let result = resolve_target(&symlink, "-rf");
+        assert!(matches!(result, Err(BaleError::UnsafeFilename(_))));
+    }
+
+    /// resolve_target rejects targets with a component exceeding NAME_MAX (255).
+    #[test]
+    fn resolve_target_rejects_long_component() {
+        let symlink = ArchivePath::try_from("link").unwrap();
+        let long = "a".repeat(257);
+        let result = resolve_target(&symlink, &long);
+        assert!(matches!(result, Err(BaleError::UnsafeFilename(_))));
+    }
+
+    /// resolve_target allows components with dashes in the middle.
+    #[test]
+    fn resolve_target_allows_dash_in_middle() {
+        let symlink = ArchivePath::try_from("link").unwrap();
+        let result = resolve_target(&symlink, "foo/bar-baz");
+        assert_eq!(result.unwrap(), "foo/bar-baz");
+    }
+
+    /// resolve_target allows a component at the NAME_MAX (255) limit.
+    #[test]
+    fn resolve_target_allows_max_length_component() {
+        let symlink = ArchivePath::try_from("link").unwrap();
+        let component = "a".repeat(255);
+        let result = resolve_target(&symlink, &component);
+        assert_eq!(result.unwrap(), component);
     }
 }

--- a/src/archive/mod.rs
+++ b/src/archive/mod.rs
@@ -30,6 +30,7 @@ mod symlink_entry;
 mod writer;
 
 pub use archive_read::ArchiveRead;
+pub(crate) use archive_read::resolve_target;
 pub use archive_write::ArchiveWrite;
 pub use core::{Archive, ArchiveReader, ArchiveWriter};
 pub use dir_entry::DirEntry;

--- a/src/archive/reader.rs
+++ b/src/archive/reader.rs
@@ -1492,4 +1492,104 @@ mod tests {
         let result = archive.resolve("file.txt/child");
         assert!(matches!(result, Err(BaleError::NotADirectory(_))));
     }
+
+    /// resolve() succeeds at exactly MAX_SYMLINK_DEPTH (256) hops.
+    #[test]
+    fn resolve_symlink_chain_at_max_depth() {
+        // Build 256 symlinks: s001 → s002 → ... → s256 → target.txt
+        let mut entries: Vec<TestEntry> = (1..=256u32)
+            .map(|i| {
+                let path: &'static str = Box::leak(format!("s{i:03}").into_boxed_str());
+                let target: &'static [u8] = if i < 256 {
+                    Box::leak(format!("s{:03}", i + 1).into_bytes().into_boxed_slice())
+                } else {
+                    b"target.txt"
+                };
+                TestEntry {
+                    path,
+                    data: target,
+                    mode: 0o120777,
+                    id: i,
+                }
+            })
+            .collect();
+        entries.push(TestEntry {
+            path: "target.txt",
+            data: b"reached",
+            mode: 0o100644,
+            id: 257,
+        });
+
+        let bytes = build_test_archive(&entries);
+        let archive = archive_from_bytes(&bytes);
+
+        let entry = archive.resolve("s001").unwrap();
+        assert!(entry.is_file());
+        let file = entry.into_file().unwrap();
+        assert_eq!(file.data(), b"reached");
+    }
+
+    /// resolve() returns SymlinkLoop when chain exceeds MAX_SYMLINK_DEPTH.
+    #[test]
+    fn resolve_symlink_chain_exceeds_max_depth() {
+        // Build 257 symlinks: s001 → s002 → ... → s257 → target.txt
+        let mut entries: Vec<TestEntry> = (1..=257u32)
+            .map(|i| {
+                let path: &'static str = Box::leak(format!("s{i:03}").into_boxed_str());
+                let target: &'static [u8] = if i < 257 {
+                    Box::leak(format!("s{:03}", i + 1).into_bytes().into_boxed_slice())
+                } else {
+                    b"target.txt"
+                };
+                TestEntry {
+                    path,
+                    data: target,
+                    mode: 0o120777,
+                    id: i,
+                }
+            })
+            .collect();
+        entries.push(TestEntry {
+            path: "target.txt",
+            data: b"unreachable",
+            mode: 0o100644,
+            id: 258,
+        });
+
+        let bytes = build_test_archive(&entries);
+        let archive = archive_from_bytes(&bytes);
+
+        let result = archive.resolve("s001");
+        assert!(matches!(result, Err(BaleError::SymlinkLoop(_))));
+    }
+
+    /// resolve() rejects backslash-prefixed absolute symlink targets.
+    #[test]
+    fn resolve_backslash_absolute_symlink_target() {
+        let bytes = build_test_archive(&[TestEntry {
+            path: "link",
+            data: b"\\foo\\bar",
+            mode: 0o120777,
+            id: 1,
+        }]);
+        let archive = archive_from_bytes(&bytes);
+
+        let result = archive.resolve("link");
+        assert!(matches!(result, Err(BaleError::InvalidPath)));
+    }
+
+    /// resolve() rejects root-escaping symlink targets like `../../outside.txt`.
+    #[test]
+    fn resolve_root_escaping_symlink_target() {
+        let bytes = build_test_archive(&[TestEntry {
+            path: "link",
+            data: b"../../outside.txt",
+            mode: 0o120777,
+            id: 1,
+        }]);
+        let archive = archive_from_bytes(&bytes);
+
+        let result = archive.resolve("link");
+        assert!(matches!(result, Err(BaleError::InvalidPath)));
+    }
 }

--- a/src/archive/writer.rs
+++ b/src/archive/writer.rs
@@ -986,9 +986,11 @@ impl ArchiveWrite for Archive<MappedArchiveMut> {
 
     /// Creates a symlink entry.
     ///
-    /// The target is validated to prevent absolute paths and paths that
-    /// escape the archive root when resolved against the symlink's parent
-    /// directory.
+    /// The target is validated to prevent absolute paths, paths that
+    /// escape the archive root, and unsafe filename components (control
+    /// characters, leading dashes, components exceeding `NAME_MAX`).
+    /// Validation is performed by [`resolve_target`](crate::archive::resolve_target),
+    /// but the raw target string is stored as-is.
     ///
     /// # Errors
     ///
@@ -996,6 +998,7 @@ impl ArchiveWrite for Archive<MappedArchiveMut> {
     /// - The path is invalid or writing fails
     /// - The target is absolute (`InvalidPath`)
     /// - The target escapes the archive root (`InvalidPath`)
+    /// - The target contains unsafe filename components (`UnsafeFilename`)
     fn add_symlink(
         &mut self,
         path: impl AsRef<str>,
@@ -1005,36 +1008,11 @@ impl ArchiveWrite for Archive<MappedArchiveMut> {
         let path = path.as_ref();
         let target = target.as_ref();
 
-        // Reject absolute symlink targets.
-        if target.starts_with('/') || target.starts_with('\\') {
-            return Err(BaleError::InvalidPath);
-        }
-
-        // Reject targets that escape the archive root when resolved
-        // against the symlink's parent directory. We only check for escape
-        // via `..` components — we intentionally skip safename and length
-        // validation since POSIX allows long symlink targets.
+        // Validate the target: rejects absolute paths, archive-root escape,
+        // and unsafe filename components. The resolved path is discarded —
+        // the raw target is stored as-is.
         let symlink_path = ArchivePath::try_from(path)?;
-        let parent = symlink_path.parent();
-        let mut depth: usize = if parent.is_empty() {
-            0
-        } else {
-            parent.as_bytes().iter().filter(|&&b| b == b'/').count() + 1
-        };
-        for component in target.split('/') {
-            match component {
-                ".." => {
-                    if depth == 0 {
-                        return Err(BaleError::InvalidPath);
-                    }
-                    depth -= 1;
-                }
-                "" | "." => {}
-                _ => {
-                    depth += 1;
-                }
-            }
-        }
+        crate::archive::resolve_target(&symlink_path, target)?;
 
         // Ensure symlink type bits are set.
         let mode = if mode & SFlag::S_IFMT.bits() == 0 {
@@ -1664,12 +1642,12 @@ mod tests {
         assert_eq!(symlink.target(), Some("../sibling"));
     }
 
-    /// add_symlink allows targets longer than the 255-byte component limit.
+    /// add_symlink rejects targets with components exceeding NAME_MAX (255).
     ///
-    /// POSIX permits symlink targets up to `PATH_MAX` (typically 4096 bytes),
-    /// so the archive should not reject them based on path component length.
+    /// Symlink target components are validated with safename rules, which
+    /// enforce the standard NAME_MAX limit per component.
     #[test]
-    fn add_symlink_allows_long_target() {
+    fn add_symlink_rejects_long_component_in_target() {
         let dir = TempDir::new().unwrap();
         let path = dir.path().join("test.bale");
 
@@ -1677,15 +1655,20 @@ mod tests {
         let long_component = "a".repeat(257);
         let target = format!("{long_component}/file.txt");
 
-        {
-            let mut writer = ArchiveWriter::create(&path).unwrap();
-            writer.add_symlink("link", &target, 0o777).unwrap();
-            writer.sync().unwrap();
-        }
+        let mut writer = ArchiveWriter::create(&path).unwrap();
+        let result = writer.add_symlink("link", &target, 0o777);
+        assert!(matches!(result, Err(BaleError::UnsafeFilename(_))));
+    }
 
-        let reader = ArchiveReader::open(&path).unwrap();
-        let symlink = reader.symlink("link").unwrap();
-        assert_eq!(symlink.target(), Some(target.as_str()));
+    /// add_symlink rejects targets with control characters in components.
+    #[test]
+    fn add_symlink_rejects_control_chars_in_target() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("test.bale");
+
+        let mut writer = ArchiveWriter::create(&path).unwrap();
+        let result = writer.add_symlink("link", "foo\x01bar", 0o777);
+        assert!(matches!(result, Err(BaleError::UnsafeFilename(_))));
     }
 
     /// replace_content on a directory returns an error.


### PR DESCRIPTION
## Summary

Closes #176.

- Add `safename::validate_file` to `resolve_target`'s component loop, rejecting symlink targets with control characters, leading dashes, or components exceeding NAME_MAX (255 bytes) at both write time and read time
- Deduplicate validation: `add_symlink` now delegates to `resolve_target` instead of using a hand-rolled depth counter
- Add symlink resolution edge-case tests from #168 (max depth boundary, backslash absolute targets, root-escaping targets)

## Test plan

- [x] `resolve_target` rejects control chars, leading dashes, long components
- [x] `resolve_target` allows dashes in middle, 255-byte components
- [x] `add_symlink` rejects long components and control chars in targets
- [x] Existing `add_symlink` tests (absolute, escaping, relative) still pass
- [x] Symlink chain at MAX_SYMLINK_DEPTH (256) succeeds, 257 returns SymlinkLoop
- [x] All 246 tests pass, clippy clean