### PR TITLE
Add size summary line to list command

### DIFF
--- a/src/bin/bale/commands/list.rs
+++ b/src/bin/bale/commands/list.rs
@@ -17,11 +17,31 @@ const EXEC_MASK: u32 = Mode::S_IXUSR.bits() | Mode::S_IXGRP.bits() | Mode::S_IXO
 
 /// Lists entries in an archive with ls -alF style output.
 ///
-/// Output format: `<permissions> <size> <date> <time> <path><indicator>`
+/// Prints a `size <bytes>` summary line followed by one line per entry.
 ///
-/// Example: `-rw-r--r--      1234 Jan  2 18:30 hello.txt`
+/// Output format:
+/// ```text
+/// size <total_bytes>
+/// <permissions> <size> <date> <time> <path><indicator>
+/// ```
+///
+/// Example:
+/// ```text
+/// size 1234
+/// -rw-r--r--      1234 Jan  2 18:30 hello.txt
+/// ```
 pub fn run(archive_path: impl AsRef<Path>) -> Result<(), BaleCliError> {
     let reader = ArchiveReader::open(archive_path)?;
+
+    let total_size: u64 = reader
+        .iter_entries()
+        .map(|(entry_row, _)| entry_row.file_size.get())
+        .sum();
+
+    #[allow(clippy::print_stdout)]
+    {
+        println!("size {total_size}");
+    }
 
     for (entry_row, path_bytes) in reader.iter_entries() {
         let path = ArchivePath::from_null_padded_bytes(path_bytes);

--- a/tests/cli_commands.rs
+++ b/tests/cli_commands.rs
@@ -54,6 +54,45 @@ fn touch_updates_mtime() {
     assert!(mtime2 > mtime1, "mtime should be updated");
 }
 
+/// List shows size 0 for empty archive.
+#[test]
+fn list_empty_archive_shows_size_zero() {
+    let dir = tempdir().unwrap();
+    let archive = dir.path().join("test.bale");
+
+    run_bale(&["touch", archive.to_str().unwrap()]);
+
+    let (success, stdout, _) = run_bale(&["ls", archive.to_str().unwrap()]);
+    assert!(success, "ls should succeed");
+    assert!(
+        stdout.starts_with("size 0\n"),
+        "empty archive should show size 0, got: {stdout}"
+    );
+}
+
+/// List shows size as sum of entry data sizes.
+#[test]
+fn list_shows_size_sum() {
+    let dir = tempdir().unwrap();
+    let archive = dir.path().join("test.bale");
+    let file1 = dir.path().join("hello.txt");
+    let file2 = dir.path().join("empty.txt");
+
+    fs::write(&file1, "Hello, World!").unwrap(); // 13 bytes
+    fs::write(&file2, "").unwrap(); // 0 bytes
+
+    run_bale(&["touch", archive.to_str().unwrap()]);
+    run_bale(&["add", archive.to_str().unwrap(), file1.to_str().unwrap()]);
+    run_bale(&["add", archive.to_str().unwrap(), file2.to_str().unwrap()]);
+
+    let (success, stdout, _) = run_bale(&["ls", archive.to_str().unwrap()]);
+    assert!(success, "ls should succeed");
+    assert!(
+        stdout.starts_with("size 13\n"),
+        "size should be sum of file sizes (13), got: {stdout}"
+    );
+}
+
 /// Add command adds files to archive.
 #[test]
 


### PR DESCRIPTION
## Summary
- Print a `size <bytes>` line before entry listing showing the sum of all entry data sizes in raw bytes
- Empty archives show `size 0`

## Test plan
- [x] `list_empty_archive_shows_size_zero` — empty archive outputs `size 0`
- [x] `list_shows_size_sum` — total equals sum of file data sizes (13 + 0 = 13)
- [x] Existing list tests continue to pass (use `contains`, unaffected by new line)
- [x] All 248 tests pass, precommit clean

Closes #160