### PR TITLE
Add unit tests for archive entry types

### DIFF
--- a/src/archive/dir_entry.rs
+++ b/src/archive/dir_entry.rs
@@ -58,3 +58,73 @@ impl<'a> DirEntry<'a> {
         self.id
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ArchivePath;
+
+    /// Creates a test directory `EntryRow` with known values.
+    fn test_entry_row() -> EntryRow {
+        EntryRow::new_directory(7, 1_700_000_000_000, 1_700_000_001_000, 0o040755)
+    }
+
+    /// Creates a `DirEntry` referencing the given row.
+    fn make_dir_entry(row: &EntryRow) -> DirEntry<'_> {
+        DirEntry {
+            entry: row,
+            path: ArchivePath::from_bytes(b"src/lib"),
+            id: 7,
+        }
+    }
+
+    /// `path()` returns the directory path.
+    #[test]
+    fn path_returns_archive_path() {
+        let row = test_entry_row();
+        let dir = make_dir_entry(&row);
+        assert_eq!(dir.path().as_bytes(), b"src/lib");
+    }
+
+    /// `mode()` returns the Unix mode from the entry row.
+    #[test]
+    fn mode_returns_unix_mode() {
+        let row = test_entry_row();
+        let dir = make_dir_entry(&row);
+        assert_eq!(dir.mode(), 0o040755);
+    }
+
+    /// `created_time()` returns the creation timestamp.
+    #[test]
+    fn created_time_returns_timestamp() {
+        let row = test_entry_row();
+        let dir = make_dir_entry(&row);
+        assert_eq!(dir.created_time(), 1_700_000_000_000);
+    }
+
+    /// `modified_time()` returns the modification timestamp.
+    #[test]
+    fn modified_time_returns_timestamp() {
+        let row = test_entry_row();
+        let dir = make_dir_entry(&row);
+        assert_eq!(dir.modified_time(), 1_700_000_001_000);
+    }
+
+    /// `entry()` returns a reference to the underlying entry row.
+    #[test]
+    fn entry_returns_row_reference() {
+        let row = test_entry_row();
+        let dir = make_dir_entry(&row);
+        let returned = dir.entry();
+        assert_eq!(returned.entry_id.get(), 7);
+        assert_eq!(returned.mode.get(), 0o040755);
+    }
+
+    /// `id()` returns the stable entry ID.
+    #[test]
+    fn id_returns_entry_id() {
+        let row = test_entry_row();
+        let dir = make_dir_entry(&row);
+        assert_eq!(dir.id(), 7);
+    }
+}

--- a/src/archive/entry.rs
+++ b/src/archive/entry.rs
@@ -119,3 +119,209 @@ impl<'a> From<SymlinkEntry<'a>> for Entry<'a> {
         Self::Symlink(entry)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ArchivePath;
+    use crate::format::{Crc, EntryRow};
+
+    /// Creates a test `FileEntry`.
+    fn make_file_entry(row: &EntryRow) -> FileEntry<'_> {
+        FileEntry {
+            entry: row,
+            path: ArchivePath::from_bytes(b"test.txt"),
+            data: b"hello",
+            id: 1,
+        }
+    }
+
+    /// Creates a test `DirEntry`.
+    fn make_dir_entry(row: &EntryRow) -> DirEntry<'_> {
+        DirEntry {
+            entry: row,
+            path: ArchivePath::from_bytes(b"src"),
+            id: 2,
+        }
+    }
+
+    /// Creates a test `SymlinkEntry`.
+    fn make_symlink_entry(row: &EntryRow) -> SymlinkEntry<'_> {
+        SymlinkEntry {
+            entry: row,
+            path: ArchivePath::from_bytes(b"link"),
+            target: b"target",
+            id: 3,
+        }
+    }
+
+    // ==================== is_* predicates ====================
+
+    /// `is_file()` returns true only for `Entry::File`.
+    #[test]
+    fn is_file_predicate() {
+        let file_row = EntryRow::new_file(1, Crc::NONE, 0, 0, 0, 0, 0, 0o100644);
+        let dir_row = EntryRow::new_directory(2, 0, 0, 0o040755);
+        let sym_row = EntryRow::new_file(3, Crc::NONE, 0, 0, 0, 0, 0, 0o120777);
+
+        let file = Entry::File(make_file_entry(&file_row));
+        let dir = Entry::Directory(make_dir_entry(&dir_row));
+        let sym = Entry::Symlink(make_symlink_entry(&sym_row));
+
+        assert!(file.is_file());
+        assert!(!dir.is_file());
+        assert!(!sym.is_file());
+    }
+
+    /// `is_directory()` returns true only for `Entry::Directory`.
+    #[test]
+    fn is_directory_predicate() {
+        let file_row = EntryRow::new_file(1, Crc::NONE, 0, 0, 0, 0, 0, 0o100644);
+        let dir_row = EntryRow::new_directory(2, 0, 0, 0o040755);
+        let sym_row = EntryRow::new_file(3, Crc::NONE, 0, 0, 0, 0, 0, 0o120777);
+
+        let file = Entry::File(make_file_entry(&file_row));
+        let dir = Entry::Directory(make_dir_entry(&dir_row));
+        let sym = Entry::Symlink(make_symlink_entry(&sym_row));
+
+        assert!(!file.is_directory());
+        assert!(dir.is_directory());
+        assert!(!sym.is_directory());
+    }
+
+    /// `is_symlink()` returns true only for `Entry::Symlink`.
+    #[test]
+    fn is_symlink_predicate() {
+        let file_row = EntryRow::new_file(1, Crc::NONE, 0, 0, 0, 0, 0, 0o100644);
+        let dir_row = EntryRow::new_directory(2, 0, 0, 0o040755);
+        let sym_row = EntryRow::new_file(3, Crc::NONE, 0, 0, 0, 0, 0, 0o120777);
+
+        let file = Entry::File(make_file_entry(&file_row));
+        let dir = Entry::Directory(make_dir_entry(&dir_row));
+        let sym = Entry::Symlink(make_symlink_entry(&sym_row));
+
+        assert!(!file.is_symlink());
+        assert!(!dir.is_symlink());
+        assert!(sym.is_symlink());
+    }
+
+    // ==================== as_* borrow conversions ====================
+
+    /// `as_file()` returns `Some` for file entries and `None` for others.
+    #[test]
+    fn as_file_conversion() {
+        let file_row = EntryRow::new_file(1, Crc::NONE, 0, 0, 0, 0, 0, 0o100644);
+        let dir_row = EntryRow::new_directory(2, 0, 0, 0o040755);
+        let sym_row = EntryRow::new_file(3, Crc::NONE, 0, 0, 0, 0, 0, 0o120777);
+
+        let file = Entry::File(make_file_entry(&file_row));
+        let dir = Entry::Directory(make_dir_entry(&dir_row));
+        let sym = Entry::Symlink(make_symlink_entry(&sym_row));
+
+        assert!(file.as_file().is_some());
+        assert_eq!(file.as_file().unwrap().id(), 1);
+        assert!(dir.as_file().is_none());
+        assert!(sym.as_file().is_none());
+    }
+
+    /// `as_directory()` returns `Some` for directory entries and `None` for others.
+    #[test]
+    fn as_directory_conversion() {
+        let file_row = EntryRow::new_file(1, Crc::NONE, 0, 0, 0, 0, 0, 0o100644);
+        let dir_row = EntryRow::new_directory(2, 0, 0, 0o040755);
+        let sym_row = EntryRow::new_file(3, Crc::NONE, 0, 0, 0, 0, 0, 0o120777);
+
+        let file = Entry::File(make_file_entry(&file_row));
+        let dir = Entry::Directory(make_dir_entry(&dir_row));
+        let sym = Entry::Symlink(make_symlink_entry(&sym_row));
+
+        assert!(file.as_directory().is_none());
+        assert!(dir.as_directory().is_some());
+        assert_eq!(dir.as_directory().unwrap().id(), 2);
+        assert!(sym.as_directory().is_none());
+    }
+
+    /// `as_symlink()` returns `Some` for symlink entries and `None` for others.
+    #[test]
+    fn as_symlink_conversion() {
+        let file_row = EntryRow::new_file(1, Crc::NONE, 0, 0, 0, 0, 0, 0o100644);
+        let dir_row = EntryRow::new_directory(2, 0, 0, 0o040755);
+        let sym_row = EntryRow::new_file(3, Crc::NONE, 0, 0, 0, 0, 0, 0o120777);
+
+        let file = Entry::File(make_file_entry(&file_row));
+        let dir = Entry::Directory(make_dir_entry(&dir_row));
+        let sym = Entry::Symlink(make_symlink_entry(&sym_row));
+
+        assert!(file.as_symlink().is_none());
+        assert!(dir.as_symlink().is_none());
+        assert!(sym.as_symlink().is_some());
+        assert_eq!(sym.as_symlink().unwrap().id(), 3);
+    }
+
+    // ==================== into_* owned conversions ====================
+
+    /// `into_file()` returns `Some` for file entries and `None` for others.
+    #[test]
+    fn into_file_conversion() {
+        let file_row = EntryRow::new_file(1, Crc::NONE, 0, 0, 0, 0, 0, 0o100644);
+        let dir_row = EntryRow::new_directory(2, 0, 0, 0o040755);
+
+        let file = Entry::File(make_file_entry(&file_row));
+        assert_eq!(file.into_file().unwrap().id(), 1);
+
+        let dir = Entry::Directory(make_dir_entry(&dir_row));
+        assert!(dir.into_file().is_none());
+    }
+
+    /// `into_directory()` returns `Some` for directory entries and `None` for others.
+    #[test]
+    fn into_directory_conversion() {
+        let dir_row = EntryRow::new_directory(2, 0, 0, 0o040755);
+        let sym_row = EntryRow::new_file(3, Crc::NONE, 0, 0, 0, 0, 0, 0o120777);
+
+        let dir = Entry::Directory(make_dir_entry(&dir_row));
+        assert_eq!(dir.into_directory().unwrap().id(), 2);
+
+        let sym = Entry::Symlink(make_symlink_entry(&sym_row));
+        assert!(sym.into_directory().is_none());
+    }
+
+    /// `into_symlink()` returns `Some` for symlink entries and `None` for others.
+    #[test]
+    fn into_symlink_conversion() {
+        let file_row = EntryRow::new_file(1, Crc::NONE, 0, 0, 0, 0, 0, 0o100644);
+        let sym_row = EntryRow::new_file(3, Crc::NONE, 0, 0, 0, 0, 0, 0o120777);
+
+        let sym = Entry::Symlink(make_symlink_entry(&sym_row));
+        assert_eq!(sym.into_symlink().unwrap().id(), 3);
+
+        let file = Entry::File(make_file_entry(&file_row));
+        assert!(file.into_symlink().is_none());
+    }
+
+    // ==================== From impls ====================
+
+    /// `From<FileEntry>` produces `Entry::File`.
+    #[test]
+    fn from_file_entry() {
+        let row = EntryRow::new_file(1, Crc::NONE, 0, 0, 0, 0, 0, 0o100644);
+        let entry: Entry<'_> = make_file_entry(&row).into();
+        assert!(entry.is_file());
+    }
+
+    /// `From<DirEntry>` produces `Entry::Directory`.
+    #[test]
+    fn from_dir_entry() {
+        let row = EntryRow::new_directory(2, 0, 0, 0o040755);
+        let entry: Entry<'_> = make_dir_entry(&row).into();
+        assert!(entry.is_directory());
+    }
+
+    /// `From<SymlinkEntry>` produces `Entry::Symlink`.
+    #[test]
+    fn from_symlink_entry() {
+        let row = EntryRow::new_file(3, Crc::NONE, 0, 0, 0, 0, 0, 0o120777);
+        let entry: Entry<'_> = make_symlink_entry(&row).into();
+        assert!(entry.is_symlink());
+    }
+}

--- a/src/archive/file_entry.rs
+++ b/src/archive/file_entry.rs
@@ -73,3 +73,100 @@ impl<'a> FileEntry<'a> {
         self.id
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ArchivePath;
+    use crate::format::Crc;
+
+    /// Creates a test file `EntryRow` with known values.
+    fn test_entry_row() -> EntryRow {
+        EntryRow::new_file(
+            3,
+            Crc::new(0xDEAD_BEEF),
+            4096,
+            1024,
+            1024,
+            1_700_000_000_000,
+            1_700_000_001_000,
+            0o100644,
+        )
+    }
+
+    /// Creates a `FileEntry` referencing the given row.
+    fn make_file_entry(row: &EntryRow) -> FileEntry<'_> {
+        FileEntry {
+            entry: row,
+            path: ArchivePath::from_bytes(b"src/main.rs"),
+            data: b"fn main() {}",
+            id: 3,
+        }
+    }
+
+    /// `data()` returns the file content bytes.
+    #[test]
+    fn data_returns_file_content() {
+        let row = test_entry_row();
+        let file = make_file_entry(&row);
+        assert_eq!(file.data(), b"fn main() {}");
+    }
+
+    /// `size()` returns the uncompressed file size from the entry row.
+    #[test]
+    fn size_returns_file_size() {
+        let row = test_entry_row();
+        let file = make_file_entry(&row);
+        assert_eq!(file.size(), 1024);
+    }
+
+    /// `path()` returns the file path.
+    #[test]
+    fn path_returns_archive_path() {
+        let row = test_entry_row();
+        let file = make_file_entry(&row);
+        assert_eq!(file.path().as_bytes(), b"src/main.rs");
+    }
+
+    /// `mode()` returns the Unix mode from the entry row.
+    #[test]
+    fn mode_returns_unix_mode() {
+        let row = test_entry_row();
+        let file = make_file_entry(&row);
+        assert_eq!(file.mode(), 0o100644);
+    }
+
+    /// `created_time()` returns the creation timestamp.
+    #[test]
+    fn created_time_returns_timestamp() {
+        let row = test_entry_row();
+        let file = make_file_entry(&row);
+        assert_eq!(file.created_time(), 1_700_000_000_000);
+    }
+
+    /// `modified_time()` returns the modification timestamp.
+    #[test]
+    fn modified_time_returns_timestamp() {
+        let row = test_entry_row();
+        let file = make_file_entry(&row);
+        assert_eq!(file.modified_time(), 1_700_000_001_000);
+    }
+
+    /// `entry()` returns a reference to the underlying entry row.
+    #[test]
+    fn entry_returns_row_reference() {
+        let row = test_entry_row();
+        let file = make_file_entry(&row);
+        let returned = file.entry();
+        assert_eq!(returned.entry_id.get(), 3);
+        assert_eq!(returned.mode.get(), 0o100644);
+    }
+
+    /// `id()` returns the stable entry ID.
+    #[test]
+    fn id_returns_entry_id() {
+        let row = test_entry_row();
+        let file = make_file_entry(&row);
+        assert_eq!(file.id(), 3);
+    }
+}

--- a/src/archive/symlink_entry.rs
+++ b/src/archive/symlink_entry.rs
@@ -78,3 +78,113 @@ impl<'a> SymlinkEntry<'a> {
         self.id
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ArchivePath;
+    use crate::format::Crc;
+
+    /// Creates a test symlink `EntryRow` with known values.
+    fn test_entry_row() -> EntryRow {
+        EntryRow::new_file(
+            5,
+            Crc::NONE,
+            4096,
+            11,
+            11,
+            1_700_000_000_000,
+            1_700_000_001_000,
+            0o120777,
+        )
+    }
+
+    /// Creates a `SymlinkEntry` referencing the given row with a UTF-8 target.
+    fn make_symlink_entry(row: &EntryRow) -> SymlinkEntry<'_> {
+        SymlinkEntry {
+            entry: row,
+            path: ArchivePath::from_bytes(b"lib/latest"),
+            target: b"lib/v2.0.1",
+            id: 5,
+        }
+    }
+
+    /// `target_bytes()` returns the raw target bytes.
+    #[test]
+    fn target_bytes_returns_raw_target() {
+        let row = test_entry_row();
+        let sym = make_symlink_entry(&row);
+        assert_eq!(sym.target_bytes(), b"lib/v2.0.1");
+    }
+
+    /// `target()` returns `Some` for valid UTF-8 targets.
+    #[test]
+    fn target_returns_some_for_valid_utf8() {
+        let row = test_entry_row();
+        let sym = make_symlink_entry(&row);
+        assert_eq!(sym.target(), Some("lib/v2.0.1"));
+    }
+
+    /// `target()` returns `None` for invalid UTF-8 targets.
+    #[test]
+    fn target_returns_none_for_invalid_utf8() {
+        let row = test_entry_row();
+        let sym = SymlinkEntry {
+            entry: &row,
+            path: ArchivePath::from_bytes(b"link"),
+            target: &[0xFF, 0xFE],
+            id: 5,
+        };
+        assert_eq!(sym.target(), None);
+    }
+
+    /// `path()` returns the symlink path.
+    #[test]
+    fn path_returns_archive_path() {
+        let row = test_entry_row();
+        let sym = make_symlink_entry(&row);
+        assert_eq!(sym.path().as_bytes(), b"lib/latest");
+    }
+
+    /// `mode()` returns the Unix mode from the entry row.
+    #[test]
+    fn mode_returns_unix_mode() {
+        let row = test_entry_row();
+        let sym = make_symlink_entry(&row);
+        assert_eq!(sym.mode(), 0o120777);
+    }
+
+    /// `created_time()` returns the creation timestamp.
+    #[test]
+    fn created_time_returns_timestamp() {
+        let row = test_entry_row();
+        let sym = make_symlink_entry(&row);
+        assert_eq!(sym.created_time(), 1_700_000_000_000);
+    }
+
+    /// `modified_time()` returns the modification timestamp.
+    #[test]
+    fn modified_time_returns_timestamp() {
+        let row = test_entry_row();
+        let sym = make_symlink_entry(&row);
+        assert_eq!(sym.modified_time(), 1_700_000_001_000);
+    }
+
+    /// `entry()` returns a reference to the underlying entry row.
+    #[test]
+    fn entry_returns_row_reference() {
+        let row = test_entry_row();
+        let sym = make_symlink_entry(&row);
+        let returned = sym.entry();
+        assert_eq!(returned.entry_id.get(), 5);
+        assert_eq!(returned.mode.get(), 0o120777);
+    }
+
+    /// `id()` returns the stable entry ID.
+    #[test]
+    fn id_returns_entry_id() {
+        let row = test_entry_row();
+        let sym = make_symlink_entry(&row);
+        assert_eq!(sym.id(), 5);
+    }
+}


### PR DESCRIPTION
## Summary
- Add `#[cfg(test)]` modules to `dir_entry.rs`, `entry.rs`, `file_entry.rs`, and `symlink_entry.rs`
- 35 new tests covering all accessors, predicates, conversions, and `From` impls
- Line coverage for these four files: 33-37% → 100%
- Overall project line coverage: 86.95% → 88.52%

## Test plan
- [x] All 35 new tests pass (`cargo nextest run`)
- [x] Full test suite passes (337 tests)
- [x] Coverage verified via `cargo-coverage`
- [x] Pre-commit hooks pass (fmt, clippy, tests)

Closes #184