### PR TITLE
Add property tests for archive entry types

### DIFF
--- a/src/archive/dir_entry.rs
+++ b/src/archive/dir_entry.rs
@@ -127,4 +127,35 @@ mod tests {
         let dir = make_dir_entry(&row);
         assert_eq!(dir.id(), 7);
     }
+
+    // ==================== Property Tests ====================
+
+    use proptest::prelude::*;
+
+    use crate::proptest_config;
+
+    proptest! {
+        #![proptest_config(proptest_config::config())]
+
+        /// All accessors round-trip arbitrary values from the entry row.
+        #[test]
+        fn accessors_round_trip(
+            id in 1..=u32::MAX,
+            created in any::<i64>(),
+            modified in any::<i64>(),
+            mode in any::<u32>(),
+        ) {
+            let row = EntryRow::new_directory(id, created, modified, mode);
+            let dir = DirEntry {
+                entry: &row,
+                path: ArchivePath::from_bytes(b"test"),
+                id,
+            };
+            prop_assert_eq!(dir.id(), id);
+            prop_assert_eq!(dir.mode(), mode);
+            prop_assert_eq!(dir.created_time(), created);
+            prop_assert_eq!(dir.modified_time(), modified);
+            prop_assert_eq!(dir.entry().entry_id.get(), id);
+        }
+    }
 }

--- a/src/archive/entry.rs
+++ b/src/archive/entry.rs
@@ -324,4 +324,108 @@ mod tests {
         let entry: Entry<'_> = make_symlink_entry(&row).into();
         assert!(entry.is_symlink());
     }
+
+    // ==================== Property Tests ====================
+
+    use proptest::prelude::*;
+
+    use crate::proptest_config;
+
+    proptest! {
+        #![proptest_config(proptest_config::config())]
+
+        /// `Entry::File` satisfies all file predicates and conversions.
+        #[test]
+        fn file_variant_properties(
+            id in 1..=u32::MAX,
+            mode in any::<u32>(),
+        ) {
+            let row = EntryRow::new_file(id, Crc::NONE, 0, 0, 0, 0, 0, mode);
+            let entry = Entry::File(FileEntry {
+                entry: &row,
+                path: ArchivePath::from_bytes(b"f"),
+                data: b"",
+                id,
+            });
+            prop_assert!(entry.is_file());
+            prop_assert!(!entry.is_directory());
+            prop_assert!(!entry.is_symlink());
+            prop_assert!(entry.as_file().is_some());
+            prop_assert_eq!(entry.as_file().unwrap().id(), id);
+            prop_assert!(entry.as_directory().is_none());
+            prop_assert!(entry.as_symlink().is_none());
+        }
+
+        /// `Entry::Directory` satisfies all directory predicates and conversions.
+        #[test]
+        fn directory_variant_properties(
+            id in 1..=u32::MAX,
+            mode in any::<u32>(),
+        ) {
+            let row = EntryRow::new_directory(id, 0, 0, mode);
+            let entry = Entry::Directory(DirEntry {
+                entry: &row,
+                path: ArchivePath::from_bytes(b"d"),
+                id,
+            });
+            prop_assert!(!entry.is_file());
+            prop_assert!(entry.is_directory());
+            prop_assert!(!entry.is_symlink());
+            prop_assert!(entry.as_file().is_none());
+            prop_assert!(entry.as_directory().is_some());
+            prop_assert_eq!(entry.as_directory().unwrap().id(), id);
+            prop_assert!(entry.as_symlink().is_none());
+        }
+
+        /// `Entry::Symlink` satisfies all symlink predicates and conversions.
+        #[test]
+        fn symlink_variant_properties(
+            id in 1..=u32::MAX,
+            mode in any::<u32>(),
+        ) {
+            let row = EntryRow::new_file(id, Crc::NONE, 0, 0, 0, 0, 0, mode);
+            let entry = Entry::Symlink(SymlinkEntry {
+                entry: &row,
+                path: ArchivePath::from_bytes(b"s"),
+                target: b"t",
+                id,
+            });
+            prop_assert!(!entry.is_file());
+            prop_assert!(!entry.is_directory());
+            prop_assert!(entry.is_symlink());
+            prop_assert!(entry.as_file().is_none());
+            prop_assert!(entry.as_directory().is_none());
+            prop_assert!(entry.as_symlink().is_some());
+            prop_assert_eq!(entry.as_symlink().unwrap().id(), id);
+        }
+
+        /// `From` conversion preserves the entry ID through `into_*`.
+        #[test]
+        fn from_into_round_trip(id in 1..=u32::MAX) {
+            let file_row = EntryRow::new_file(id, Crc::NONE, 0, 0, 0, 0, 0, 0o100644);
+            let dir_row = EntryRow::new_directory(id, 0, 0, 0o040755);
+            let sym_row = EntryRow::new_file(id, Crc::NONE, 0, 0, 0, 0, 0, 0o120777);
+
+            let file_entry = FileEntry {
+                entry: &file_row, path: ArchivePath::from_bytes(b"f"),
+                data: b"", id,
+            };
+            let dir_entry_val = DirEntry {
+                entry: &dir_row, path: ArchivePath::from_bytes(b"d"), id,
+            };
+            let sym_entry = SymlinkEntry {
+                entry: &sym_row, path: ArchivePath::from_bytes(b"s"),
+                target: b"t", id,
+            };
+
+            let e: Entry<'_> = file_entry.into();
+            prop_assert_eq!(e.into_file().unwrap().id(), id);
+
+            let e: Entry<'_> = dir_entry_val.into();
+            prop_assert_eq!(e.into_directory().unwrap().id(), id);
+
+            let e: Entry<'_> = sym_entry.into();
+            prop_assert_eq!(e.into_symlink().unwrap().id(), id);
+        }
+    }
 }

--- a/src/archive/file_entry.rs
+++ b/src/archive/file_entry.rs
@@ -169,4 +169,46 @@ mod tests {
         let file = make_file_entry(&row);
         assert_eq!(file.id(), 3);
     }
+
+    // ==================== Property Tests ====================
+
+    use proptest::prelude::*;
+
+    use crate::proptest_config;
+
+    proptest! {
+        #![proptest_config(proptest_config::config())]
+
+        /// All accessors round-trip arbitrary values from the entry row.
+        #[test]
+        fn accessors_round_trip(
+            id in 1..=u32::MAX,
+            crc_val in any::<u32>(),
+            offset in any::<u64>(),
+            file_size in any::<u64>(),
+            block_size in any::<u64>(),
+            created in any::<i64>(),
+            modified in any::<i64>(),
+            mode in any::<u32>(),
+        ) {
+            let row = EntryRow::new_file(
+                id, Crc::new(crc_val), offset,
+                file_size, block_size, created, modified, mode,
+            );
+            let data = b"proptest data";
+            let file = FileEntry {
+                entry: &row,
+                path: ArchivePath::from_bytes(b"test"),
+                data: data.as_slice(),
+                id,
+            };
+            prop_assert_eq!(file.id(), id);
+            prop_assert_eq!(file.size(), file_size);
+            prop_assert_eq!(file.mode(), mode);
+            prop_assert_eq!(file.created_time(), created);
+            prop_assert_eq!(file.modified_time(), modified);
+            prop_assert_eq!(file.data(), data.as_slice());
+            prop_assert_eq!(file.entry().entry_id.get(), id);
+        }
+    }
 }

--- a/src/archive/symlink_entry.rs
+++ b/src/archive/symlink_entry.rs
@@ -187,4 +187,81 @@ mod tests {
         let sym = make_symlink_entry(&row);
         assert_eq!(sym.id(), 5);
     }
+
+    // ==================== Property Tests ====================
+
+    use proptest::prelude::*;
+
+    use crate::proptest_config;
+
+    proptest! {
+        #![proptest_config(proptest_config::config())]
+
+        /// All accessors round-trip arbitrary values from the entry row.
+        #[test]
+        fn accessors_round_trip(
+            id in 1..=u32::MAX,
+            created in any::<i64>(),
+            modified in any::<i64>(),
+            mode in any::<u32>(),
+        ) {
+            let row = EntryRow::new_file(
+                id, Crc::NONE, 4096, 10, 10, created, modified, mode,
+            );
+            let sym = SymlinkEntry {
+                entry: &row,
+                path: ArchivePath::from_bytes(b"test"),
+                target: b"target",
+                id,
+            };
+            prop_assert_eq!(sym.id(), id);
+            prop_assert_eq!(sym.mode(), mode);
+            prop_assert_eq!(sym.created_time(), created);
+            prop_assert_eq!(sym.modified_time(), modified);
+            prop_assert_eq!(sym.entry().entry_id.get(), id);
+        }
+
+        /// `target()` returns `Some` for valid UTF-8 strings.
+        #[test]
+        fn target_valid_utf8(target in "[a-zA-Z0-9/_.-]{1,50}") {
+            let row = EntryRow::new_file(
+                1, Crc::NONE, 4096, target.len() as u64,
+                target.len() as u64, 0, 0, 0o120777,
+            );
+            let target_bytes = target.as_bytes();
+            let sym = SymlinkEntry {
+                entry: &row,
+                path: ArchivePath::from_bytes(b"link"),
+                target: target_bytes,
+                id: 1,
+            };
+            prop_assert_eq!(sym.target(), Some(target.as_str()));
+            prop_assert_eq!(sym.target_bytes(), target_bytes);
+        }
+
+        /// `target()` returns `None` for invalid UTF-8 bytes.
+        ///
+        /// Uses lone continuation bytes (0x80..=0xBF) which are always
+        /// invalid without a preceding multi-byte start byte.
+        #[test]
+        fn target_invalid_utf8(
+            byte in 0x80u8..=0xBFu8,
+            padding in prop::collection::vec(0x80u8..=0xBFu8, 0..=4),
+        ) {
+            let mut target = vec![byte];
+            target.extend_from_slice(&padding);
+            let row = EntryRow::new_file(
+                1, Crc::NONE, 4096, target.len() as u64,
+                target.len() as u64, 0, 0, 0o120777,
+            );
+            let sym = SymlinkEntry {
+                entry: &row,
+                path: ArchivePath::from_bytes(b"link"),
+                target: &target,
+                id: 1,
+            };
+            prop_assert!(sym.target().is_none());
+            prop_assert_eq!(sym.target_bytes(), target.as_slice());
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- Add proptest-based property tests to `dir_entry.rs`, `entry.rs`, `file_entry.rs`, and `symlink_entry.rs`
- 9 new property tests exercising accessors with randomized inputs, variant predicate/conversion invariants, `From`/`into_*` round-trips, and symlink target UTF-8 validity
- Complements the unit tests from #185 with input breadth rather than new code paths

## Test plan
- [x] All 346 tests pass (`cargo nextest run`)
- [x] Pre-commit hooks pass (fmt, clippy, tests)

Closes #186