### PR TITLE
Add path context to BaleError::InvalidPath

### DIFF
--- a/src/archive/archive_read.rs
+++ b/src/archive/archive_read.rs
@@ -27,7 +27,7 @@ pub(crate) fn resolve_target(
 ) -> Result<String, BaleError> {
     // Reject absolute symlink targets (defense against malicious archives).
     if target.starts_with('/') || target.starts_with('\\') {
-        return Err(BaleError::InvalidPath);
+        return Err(BaleError::InvalidPath(target.to_string()));
     }
 
     let parent = symlink_path.parent();
@@ -48,7 +48,7 @@ pub(crate) fn resolve_target(
             "" | "." => {}
             ".." => {
                 if components.pop().is_none() {
-                    return Err(BaleError::InvalidPath);
+                    return Err(BaleError::InvalidPath(target.to_string()));
                 }
             }
             component => {
@@ -59,7 +59,7 @@ pub(crate) fn resolve_target(
     }
 
     if components.is_empty() {
-        return Err(BaleError::InvalidPath);
+        return Err(BaleError::InvalidPath(target.to_string()));
     }
 
     Ok(components.join("/"))
@@ -252,7 +252,9 @@ pub trait ArchiveRead {
                     if depth > MAX_SYMLINK_DEPTH {
                         return Err(BaleError::SymlinkLoop(current_path));
                     }
-                    let target = symlink.target().ok_or(BaleError::InvalidPath)?;
+                    let target = symlink
+                        .target()
+                        .ok_or_else(|| BaleError::InvalidPath(current_path.clone()))?;
                     current_path = resolve_target(symlink.path(), target)?;
                     continue;
                 }
@@ -281,7 +283,9 @@ pub trait ArchiveRead {
                         if depth > MAX_SYMLINK_DEPTH {
                             return Err(BaleError::SymlinkLoop(current_path));
                         }
-                        let target = symlink.target().ok_or(BaleError::InvalidPath)?;
+                        let target = symlink
+                            .target()
+                            .ok_or_else(|| BaleError::InvalidPath(resolved.clone()))?;
                         let resolved_target = resolve_target(symlink.path(), target)?;
                         current_path = if remaining.is_empty() {
                             resolved_target

--- a/src/archive/reader.rs
+++ b/src/archive/reader.rs
@@ -1475,7 +1475,7 @@ mod tests {
         let archive = archive_from_bytes(&bytes);
 
         let result = archive.resolve("link");
-        assert!(matches!(result, Err(BaleError::InvalidPath)));
+        assert!(matches!(result, Err(BaleError::InvalidPath(_))));
     }
 
     /// resolve() returns NotADirectory when a file is used as a directory.
@@ -1575,7 +1575,7 @@ mod tests {
         let archive = archive_from_bytes(&bytes);
 
         let result = archive.resolve("link");
-        assert!(matches!(result, Err(BaleError::InvalidPath)));
+        assert!(matches!(result, Err(BaleError::InvalidPath(_))));
     }
 
     /// resolve() rejects root-escaping symlink targets like `../../outside.txt`.
@@ -1590,6 +1590,6 @@ mod tests {
         let archive = archive_from_bytes(&bytes);
 
         let result = archive.resolve("link");
-        assert!(matches!(result, Err(BaleError::InvalidPath)));
+        assert!(matches!(result, Err(BaleError::InvalidPath(_))));
     }
 }

--- a/src/archive/writer.rs
+++ b/src/archive/writer.rs
@@ -616,7 +616,9 @@ impl ArchiveWrite for Archive<MappedArchiveMut> {
     ) -> Result<(), BaleError> {
         // Validate and normalize path.
         let normalized = ArchivePath::from_bytes(path.as_bytes()).normalize()?;
-        let normalized_str = normalized.as_str().ok_or(BaleError::InvalidPath)?;
+        let normalized_str = normalized
+            .as_str()
+            .ok_or_else(|| BaleError::InvalidPath(path.to_string()))?;
 
         // Check path fits within path_size.
         let padded = self.pad_path(normalized_str)?;
@@ -731,7 +733,9 @@ impl ArchiveWrite for Archive<MappedArchiveMut> {
 
         // Normalize the link path.
         let normalized = ArchivePath::from_bytes(link.as_bytes()).normalize()?;
-        let normalized_str = normalized.as_str().ok_or(BaleError::InvalidPath)?;
+        let normalized_str = normalized
+            .as_str()
+            .ok_or_else(|| BaleError::InvalidPath(link.to_string()))?;
 
         // Verify link path doesn't already exist.
         if self.find_entry(normalized_str).is_some() {
@@ -782,9 +786,13 @@ impl ArchiveWrite for Archive<MappedArchiveMut> {
     fn rename(&mut self, from: &str, to: &str) -> Result<(), BaleError> {
         // Normalize both paths.
         let from_norm = ArchivePath::from_bytes(from.as_bytes()).normalize()?;
-        let from_str = from_norm.as_str().ok_or(BaleError::InvalidPath)?;
+        let from_str = from_norm
+            .as_str()
+            .ok_or_else(|| BaleError::InvalidPath(from.to_string()))?;
         let to_norm = ArchivePath::from_bytes(to.as_bytes()).normalize()?;
-        let to_str = to_norm.as_str().ok_or(BaleError::InvalidPath)?;
+        let to_str = to_norm
+            .as_str()
+            .ok_or_else(|| BaleError::InvalidPath(to.to_string()))?;
 
         let path_size = self.trailer.path_size() as usize;
 
@@ -1616,7 +1624,7 @@ mod tests {
 
         let mut writer = ArchiveWriter::create(&path).unwrap();
         let result = writer.add_symlink("link", "/usr/share/data.txt", 0o777);
-        assert!(matches!(result, Err(BaleError::InvalidPath)));
+        assert!(matches!(result, Err(BaleError::InvalidPath(_))));
     }
 
     /// add_symlink rejects targets that escape the archive root via `..`.
@@ -1627,7 +1635,7 @@ mod tests {
 
         let mut writer = ArchiveWriter::create(&path).unwrap();
         let result = writer.add_symlink("link", "../../outside.txt", 0o777);
-        assert!(matches!(result, Err(BaleError::InvalidPath)));
+        assert!(matches!(result, Err(BaleError::InvalidPath(_))));
     }
 
     /// add_symlink allows relative targets that stay within the archive.

--- a/src/archive_path.rs
+++ b/src/archive_path.rs
@@ -223,7 +223,9 @@ impl<'a> ArchivePath<'a> {
     /// - The path attempts to escape the archive root (e.g., `../etc/passwd`)
     /// - The path is empty after normalization
     pub fn normalize(&self) -> Result<ArchivePath<'static>, BaleError> {
-        let s = self.as_str().ok_or(BaleError::InvalidPath)?;
+        let s = self
+            .as_str()
+            .ok_or_else(|| BaleError::InvalidPath(format!("{:?}", self.as_bytes())))?;
         Ok(ArchivePath(Cow::Owned(
             Self::normalize_bytes(s)?.into_owned(),
         )))
@@ -287,12 +289,12 @@ impl<'a> ArchivePath<'a> {
                 ".." => {
                     if components.pop().is_none() {
                         // Attempted to go above root - path traversal attack
-                        return Err(BaleError::InvalidPath);
+                        return Err(BaleError::InvalidPath(path.to_string()));
                     }
                 }
                 component if component.trim().is_empty() => {
                     // Whitespace-only component - reject
-                    return Err(BaleError::InvalidPath);
+                    return Err(BaleError::InvalidPath(path.to_string()));
                 }
                 component => {
                     components.push(component);
@@ -301,7 +303,7 @@ impl<'a> ArchivePath<'a> {
         }
 
         if components.is_empty() {
-            return Err(BaleError::InvalidPath);
+            return Err(BaleError::InvalidPath(path.to_string()));
         }
 
         // Validate each component against safename rules and reserved prefixes.
@@ -470,7 +472,9 @@ impl TryFrom<&Path> for ArchivePath<'static> {
     type Error = BaleError;
 
     fn try_from(path: &Path) -> Result<Self, Self::Error> {
-        let s = path.to_str().ok_or(BaleError::InvalidPath)?;
+        let s = path
+            .to_str()
+            .ok_or_else(|| BaleError::InvalidPath(format!("{path:?}")))?;
         Ok(Self(Cow::Owned(Self::normalize_bytes(s)?.into_owned())))
     }
 }

--- a/src/bin/bale/commands/add.rs
+++ b/src/bin/bale/commands/add.rs
@@ -21,9 +21,12 @@ pub fn run(
         let name = file.file_name().unwrap_or(file.as_os_str());
         let dest = Path::new(prefix).join(name);
         let entry_path = ArchivePath::try_from(dest)?;
-        let entry_str = entry_path
-            .as_str()
-            .ok_or(BaleCliError::Bale(bale::BaleError::InvalidPath))?;
+        let entry_str = entry_path.as_str().ok_or_else(|| {
+            BaleCliError::Bale(bale::BaleError::InvalidPath(format!(
+                "{:?}",
+                entry_path.as_bytes()
+            )))
+        })?;
 
         writer.add_file(file, entry_str)?;
         added_count += 1;

--- a/src/bin/bale/commands/extract.rs
+++ b/src/bin/bale/commands/extract.rs
@@ -70,7 +70,9 @@ fn extract_entry(
     // Normalize path: validates UTF-8, rejects `..` traversal, removes
     // leading slashes. The result is a safe relative path.
     let normalized = archive_path.normalize()?;
-    let path_str = normalized.as_str().ok_or(BaleError::InvalidPath)?;
+    let path_str = normalized
+        .as_str()
+        .ok_or_else(|| BaleError::InvalidPath(format!("{path_bytes:?}")))?;
 
     let dest_path = output_dir.join(path_str);
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -34,8 +34,8 @@ pub enum BaleError {
     InvalidPathSize(u16),
 
     /// Path is invalid (traversal, empty, or malformed).
-    #[error("invalid path")]
-    InvalidPath,
+    #[error("invalid path: {0}")]
+    InvalidPath(String),
 
     /// Filename contains unsafe characters or patterns.
     #[error("unsafe filename: {0}")]

--- a/src/fuse/bale_fs_state.rs
+++ b/src/fuse/bale_fs_state.rs
@@ -157,7 +157,7 @@ impl BaleFsState {
         ArchivePath::try_from(path).map_err(|e| match e {
             BaleError::UnsafeFilename(_) => libc::EINVAL,
             BaleError::ReservedPath(_) => libc::EINVAL,
-            BaleError::InvalidPath => libc::EINVAL,
+            BaleError::InvalidPath(_) => libc::EINVAL,
             _ => libc::EIO,
         })?;
         Ok(())


### PR DESCRIPTION
## Summary

- Changes `BaleError::InvalidPath` from a unit variant to `InvalidPath(String)` so error messages include the offending path
- Updates all 13 call sites across the codebase to provide appropriate context (input path, symlink target, debug-formatted bytes for non-UTF-8)
- Updates test assertions to match the new `InvalidPath(_)` pattern

## Test plan

- [x] All 346 tests pass
- [x] Clippy clean with `--all-features`
- [x] All pre-commit hooks pass (fmt, clippy, tests, doc tests, no-default-features check)

Closes #189