### PR TITLE
Fix delete command silently ignoring partial failures

### DIFF
--- a/src/bin/bale/commands/delete.rs
+++ b/src/bin/bale/commands/delete.rs
@@ -8,7 +8,7 @@ use crate::error::BaleCliError;
 
 /// Deletes entries from an archive.
 ///
-/// Returns an error if no entries were deleted, unless `ignore_missing` is true.
+/// Returns an error if any requested entries are missing, unless `ignore_missing` is true.
 pub fn run(
     archive_path: impl AsRef<Path>,
     entries: &[String],
@@ -42,8 +42,8 @@ pub fn run(
         println!("Deleted {deleted_count} entries");
     }
 
-    // Error if nothing was deleted (unless --ignore-missing).
-    if deleted_count == 0 && !ignore_missing {
+    // Error if any entries were missing (unless --ignore-missing).
+    if !missing.is_empty() && !ignore_missing {
         return Err(BaleError::EntryNotFound(missing.join(", ")).into());
     }
 


### PR DESCRIPTION
## Summary

- Changes the error condition from `deleted_count == 0` to `!missing.is_empty()` so the command errors when **any** requested entries are missing, not only when all fail
- The `--ignore-missing` flag continues to suppress this error

## Test plan

- [x] All 346 tests pass
- [x] All pre-commit hooks pass

Closes #192