### PR TITLE
Add 32 targeted unit tests across 5 core modules

### DIFF
--- a/src/archive/writer.rs
+++ b/src/archive/writer.rs
@@ -1697,4 +1697,170 @@ mod tests {
         let result = writer.replace_content("mydir", b"data", 0o100644);
         assert!(matches!(result, Err(BaleError::NotAFile(_))));
     }
+
+    /// `add_file` with a nonexistent source path returns an I/O error.
+    #[test]
+    fn add_file_nonexistent_source_returns_error() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("test.bale");
+        let mut writer = ArchiveWriter::create(&path).unwrap();
+        let result = writer.add_file("/nonexistent/path/file.txt", "file.txt");
+        assert!(matches!(result, Err(BaleError::Io(_))));
+    }
+
+    /// `add_file` reads data from disk and it round-trips through the archive.
+    #[test]
+    fn add_file_reads_data_from_disk() {
+        let dir = TempDir::new().unwrap();
+        let src = dir.path().join("source.txt");
+        std::fs::write(&src, b"round-trip content").unwrap();
+
+        let archive_path = dir.path().join("test.bale");
+        {
+            let mut writer = ArchiveWriter::create(&archive_path).unwrap();
+            writer.add_file(&src, "source.txt").unwrap();
+            writer.sync().unwrap();
+        }
+
+        let reader = crate::ArchiveReader::open(&archive_path).unwrap();
+        let file = reader.file("source.txt").unwrap();
+        assert_eq!(file.data, b"round-trip content");
+    }
+
+    /// `add_symlink` sets symlink mode bits and preserves the target.
+    #[test]
+    fn add_symlink_basic_roundtrip() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("test.bale");
+
+        {
+            let mut writer = ArchiveWriter::create(&path).unwrap();
+            // Pass mode without type bits — add_symlink should set S_IFLNK.
+            writer.add_symlink("mylink", "target_file", 0o777).unwrap();
+            writer.sync().unwrap();
+        }
+
+        let reader = crate::ArchiveReader::open(&path).unwrap();
+        let entry = reader.find_entry("mylink").unwrap();
+        assert_eq!(entry.kind(), EntryKind::Symlink);
+        // S_IFLNK (0o120000) should be set in mode.
+        assert_eq!(entry.mode.get() & 0o170000, 0o120000);
+        let symlink = reader.symlink("mylink").unwrap();
+        assert_eq!(symlink.target(), Some("target_file"));
+    }
+
+    /// `add_symlink` preserves explicit `S_IFLNK` mode bits without doubling.
+    #[test]
+    fn add_symlink_preserves_explicit_mode_bits() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("test.bale");
+
+        {
+            let mut writer = ArchiveWriter::create(&path).unwrap();
+            // Pass mode with S_IFLNK already set.
+            writer
+                .add_symlink("mylink", "target_file", 0o120777)
+                .unwrap();
+            writer.sync().unwrap();
+        }
+
+        let reader = crate::ArchiveReader::open(&path).unwrap();
+        let entry = reader.find_entry("mylink").unwrap();
+        assert_eq!(entry.mode.get(), 0o120777);
+    }
+
+    /// `hard_link` to a nonexistent target returns `EntryNotFound`.
+    #[test]
+    fn hard_link_nonexistent_target_returns_error() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("test.bale");
+
+        let mut writer = ArchiveWriter::create(&path).unwrap();
+        let result = writer.hard_link("nonexistent", "link");
+        assert!(matches!(result, Err(BaleError::EntryNotFound(_))));
+    }
+
+    /// Symlinks can be hard linked (only directories are forbidden).
+    #[test]
+    fn hard_link_symlink_allowed() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("test.bale");
+
+        {
+            let mut writer = ArchiveWriter::create(&path).unwrap();
+            writer
+                .add_symlink("original_link", "target", 0o777)
+                .unwrap();
+            writer.hard_link("original_link", "second_link").unwrap();
+            writer.sync().unwrap();
+        }
+
+        let reader = crate::ArchiveReader::open(&path).unwrap();
+        let orig = reader.symlink("original_link").unwrap();
+        let link = reader.symlink("second_link").unwrap();
+        assert_eq!(orig.id, link.id);
+        assert_eq!(orig.target(), Some("target"));
+        assert_eq!(link.target(), Some("target"));
+    }
+
+    /// `rename` with a nonexistent source returns `EntryNotFound`.
+    #[test]
+    fn rename_nonexistent_source_returns_error() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("test.bale");
+
+        let mut writer = ArchiveWriter::create(&path).unwrap();
+        let result = writer.rename("nonexistent", "new_name");
+        assert!(matches!(result, Err(BaleError::EntryNotFound(_))));
+    }
+
+    /// `rename` to an existing destination returns `PathExists`.
+    #[test]
+    fn rename_to_existing_destination_returns_error() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("test.bale");
+
+        let mut writer = ArchiveWriter::create(&path).unwrap();
+        writer.add_entry("src.txt", b"src", 0o100644).unwrap();
+        writer.add_entry("dst.txt", b"dst", 0o100644).unwrap();
+        let result = writer.rename("src.txt", "dst.txt");
+        assert!(matches!(result, Err(BaleError::PathExists(_))));
+    }
+
+    /// Calling `sync` twice is safe and the archive remains unchanged.
+    #[test]
+    fn sync_idempotency() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("test.bale");
+
+        {
+            let mut writer = ArchiveWriter::create(&path).unwrap();
+            writer.add_entry("file.txt", b"data", 0o100644).unwrap();
+            writer.sync().unwrap();
+            writer.sync().unwrap();
+        }
+
+        let reader = crate::ArchiveReader::open(&path).unwrap();
+        assert_eq!(reader.entry_count(), 1);
+        assert_eq!(reader.file("file.txt").unwrap().data, b"data");
+    }
+
+    /// Path at exactly `path_size` succeeds; one byte longer fails.
+    #[test]
+    fn path_at_max_length_boundary() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("test.bale");
+
+        let path_size: u16 = 16;
+        let mut writer = ArchiveWriter::create_with_options(&path, 4096, path_size).unwrap();
+
+        // Exact fit: 16 bytes.
+        let exact_path = "a".repeat(path_size as usize);
+        writer.add_entry(&exact_path, b"data", 0o100644).unwrap();
+
+        // One byte too long: 17 bytes.
+        let long_path = "b".repeat(path_size as usize + 1);
+        let result = writer.add_entry(&long_path, b"data", 0o100644);
+        assert!(matches!(result, Err(BaleError::PathTooLong { .. })));
+    }
 }

--- a/src/compact.rs
+++ b/src/compact.rs
@@ -595,4 +595,158 @@ mod tests {
 
         assert_eq!(paths, vec!["a.txt", "z(1).txt", "z.txt"]);
     }
+
+    /// Compacting 3 entries with the same path keeps only the last one.
+    #[test]
+    fn compact_all_duplicates() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("test.bale");
+
+        {
+            let mut writer = ArchiveWriter::create(&path).unwrap();
+            writer.add_entry("file.txt", b"v1", 0o644).unwrap();
+            writer.add_entry("file.txt", b"v2", 0o644).unwrap();
+            writer.add_entry("file.txt", b"v3", 0o644).unwrap();
+            writer.sync().unwrap();
+        }
+
+        let stats = compact(&path).unwrap();
+        assert_eq!(stats.entries_removed, 2);
+
+        let reader = ArchiveReader::open(&path).unwrap();
+        assert_eq!(reader.entry_count(), 1);
+        let data = reader
+            .read_data(reader.find_entry("file.txt").unwrap())
+            .unwrap();
+        assert_eq!(data, b"v3");
+    }
+
+    /// Hard-linked entries survive compaction.
+    #[test]
+    fn compact_preserves_hard_links() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("test.bale");
+
+        {
+            let mut writer = ArchiveWriter::create(&path).unwrap();
+            writer
+                .add_entry("original.txt", b"shared data", 0o100644)
+                .unwrap();
+            writer.hard_link("original.txt", "link.txt").unwrap();
+            writer.sync().unwrap();
+        }
+
+        compact(&path).unwrap();
+
+        // After compaction, both paths should exist with the same data.
+        // Note: compact re-writes entries individually, so they become
+        // separate entries with identical content (not shared entry IDs).
+        let reader = ArchiveReader::open(&path).unwrap();
+        let orig = reader.file("original.txt").unwrap();
+        let link = reader.file("link.txt").unwrap();
+        assert_eq!(orig.data, b"shared data");
+        assert_eq!(link.data, b"shared data");
+    }
+
+    /// Symlink target and mode are preserved through compaction.
+    #[test]
+    fn compact_handles_symlinks() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("test.bale");
+
+        {
+            let mut writer = ArchiveWriter::create(&path).unwrap();
+            writer
+                .add_entry("target.txt", b"target data", 0o100644)
+                .unwrap();
+            writer.add_symlink("mylink", "target.txt", 0o777).unwrap();
+            writer.sync().unwrap();
+        }
+
+        compact(&path).unwrap();
+
+        let reader = ArchiveReader::open(&path).unwrap();
+        let entry = reader.find_entry("mylink").unwrap();
+        assert_eq!(entry.kind(), EntryKind::Symlink);
+        // Mode should preserve symlink type bits.
+        assert_eq!(entry.mode.get() & 0o170000, 0o120000);
+        let data = reader.read_data(entry).unwrap();
+        assert_eq!(data, b"target.txt");
+    }
+
+    /// Compaction creates implicit parent directories for files.
+    #[test]
+    fn compact_creates_implicit_directories() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("test.bale");
+
+        {
+            let mut writer = ArchiveWriter::create(&path).unwrap();
+            // Add a file without its parent directory.
+            writer
+                .add_entry("a/b/file.txt", b"nested", 0o100644)
+                .unwrap();
+            writer.sync().unwrap();
+        }
+
+        compact(&path).unwrap();
+
+        let reader = ArchiveReader::open(&path).unwrap();
+        // The implicit directories should have been created.
+        let dir_a = reader.find_entry("a").unwrap();
+        assert_eq!(dir_a.kind(), EntryKind::Directory);
+        let dir_ab = reader.find_entry("a/b").unwrap();
+        assert_eq!(dir_ab.kind(), EntryKind::Directory);
+        // The file should still exist.
+        let file = reader.file("a/b/file.txt").unwrap();
+        assert_eq!(file.data, b"nested");
+    }
+
+    /// Rename duplicates produces `file(1).txt`, `file(2).txt` suffixes.
+    #[test]
+    fn rename_duplicates_suffix_format() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("test.bale");
+
+        {
+            let mut writer = ArchiveWriter::create(&path).unwrap();
+            writer.add_entry("doc.md", b"first", 0o644).unwrap();
+            writer.add_entry("doc.md", b"second", 0o644).unwrap();
+            writer.add_entry("doc.md", b"third", 0o644).unwrap();
+            writer.add_entry("doc.md", b"fourth", 0o644).unwrap();
+            writer.sync().unwrap();
+        }
+
+        let stats = rename_duplicates(&path).unwrap();
+        assert_eq!(stats.entries_renamed, 3);
+
+        let reader = ArchiveReader::open(&path).unwrap();
+        assert_eq!(reader.entry_count(), 4);
+        // Last occurrence keeps the original name.
+        assert_eq!(
+            reader
+                .read_data(reader.find_entry("doc.md").unwrap())
+                .unwrap(),
+            b"fourth"
+        );
+        // Earlier occurrences get sequential suffixes.
+        assert_eq!(
+            reader
+                .read_data(reader.find_entry("doc(1).md").unwrap())
+                .unwrap(),
+            b"first"
+        );
+        assert_eq!(
+            reader
+                .read_data(reader.find_entry("doc(2).md").unwrap())
+                .unwrap(),
+            b"second"
+        );
+        assert_eq!(
+            reader
+                .read_data(reader.find_entry("doc(3).md").unwrap())
+                .unwrap(),
+            b"third"
+        );
+    }
 }

--- a/src/format/crc.rs
+++ b/src/format/crc.rs
@@ -111,4 +111,35 @@ mod tests {
         assert_ne!(Crc::new(42), Crc::new(43));
         assert_eq!(Crc::NONE, Crc::new(0));
     }
+
+    /// Multi-segment append produces the same CRC as a single-pass compute.
+    #[test]
+    fn append_multi_segment_matches_single_pass() {
+        let a = b"Hello, ";
+        let b = b"beautiful ";
+        let c = b"World!";
+        let combined = [a.as_slice(), b.as_slice(), c.as_slice()].concat();
+
+        let incremental = Crc::compute(a).append(b).append(c);
+        let single_pass = Crc::compute(&combined);
+        assert_eq!(incremental, single_pass);
+    }
+
+    /// Appending data to `Crc::NONE` matches computing from scratch.
+    #[test]
+    fn append_from_none_matches_compute() {
+        let data = b"some input data";
+        let from_none = Crc::NONE.append(data);
+        let computed = Crc::compute(data);
+        assert_eq!(from_none, computed);
+    }
+
+    /// Same input always produces the same CRC output.
+    #[test]
+    fn compute_deterministic() {
+        let data = b"deterministic check";
+        let first = Crc::compute(data);
+        let second = Crc::compute(data);
+        assert_eq!(first, second);
+    }
 }

--- a/src/format/entry_row.rs
+++ b/src/format/entry_row.rs
@@ -225,4 +225,64 @@ mod tests {
         assert_eq!(restored.compression, EntryRow::COMPRESSION_NONE);
         assert_eq!(restored.flags, 0);
     }
+
+    /// Maximum entry ID (`u32::MAX`) round-trips through serialization.
+    #[test]
+    fn boundary_entry_id_max() {
+        let row = EntryRow::new_file(u32::MAX, Crc::NONE, 0, 0, 0, 0, 0, 0o100644);
+        let bytes = row.as_bytes();
+        let restored = EntryRow::ref_from_bytes(bytes).unwrap();
+        assert_eq!(restored.entry_id.get(), u32::MAX);
+    }
+
+    /// Maximum `u64` values for `file_size` and `block_size` round-trip.
+    #[test]
+    fn boundary_file_size_max() {
+        let row = EntryRow::new_file(1, Crc::NONE, 0, u64::MAX, u64::MAX, 0, 0, 0o100644);
+        let bytes = row.as_bytes();
+        let restored = EntryRow::ref_from_bytes(bytes).unwrap();
+        assert_eq!(restored.file_size.get(), u64::MAX);
+        assert_eq!(restored.block_size.get(), u64::MAX);
+    }
+
+    /// Extreme `i64` timestamp values (`MIN` and `MAX`) round-trip.
+    #[test]
+    fn boundary_timestamps_min_max() {
+        let row = EntryRow::new_file(1, Crc::NONE, 0, 0, 0, i64::MIN, i64::MAX, 0o100644);
+        let bytes = row.as_bytes();
+        let restored = EntryRow::ref_from_bytes(bytes).unwrap();
+        assert_eq!(restored.created_time.get(), i64::MIN);
+        assert_eq!(restored.modified_time.get(), i64::MAX);
+    }
+
+    /// Maximum `u64` data offset round-trips through serialization.
+    #[test]
+    fn boundary_data_offset_max() {
+        let row = EntryRow::new_file(1, Crc::NONE, u64::MAX, 0, 0, 0, 0, 0o100644);
+        let bytes = row.as_bytes();
+        let restored = EntryRow::ref_from_bytes(bytes).unwrap();
+        assert_eq!(restored.data_offset.get(), u64::MAX);
+    }
+
+    /// Non-default compression and flags survive serialization.
+    #[test]
+    fn compression_and_flags_roundtrip() {
+        let mut row = EntryRow::new_file(1, Crc::NONE, 0, 0, 0, 0, 0, 0o100644);
+        row.compression = 7;
+        row.flags = 0b1010_0101;
+        let bytes = row.as_bytes();
+        let restored = EntryRow::ref_from_bytes(bytes).unwrap();
+        assert_eq!(restored.compression, 7);
+        assert_eq!(restored.flags, 0b1010_0101);
+    }
+
+    /// Non-zero reserved bytes survive serialization.
+    #[test]
+    fn reserved_field_roundtrip() {
+        let mut row = EntryRow::new_file(1, Crc::NONE, 0, 0, 0, 0, 0, 0o100644);
+        row.reserved = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+        let bytes = row.as_bytes();
+        let restored = EntryRow::ref_from_bytes(bytes).unwrap();
+        assert_eq!(restored.reserved, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+    }
 }

--- a/src/mmap/mapped_archive_mut.rs
+++ b/src/mmap/mapped_archive_mut.rs
@@ -370,4 +370,104 @@ mod tests {
         let result = MappedArchiveMut::open(file.path());
         assert!(matches!(result, Err(BaleError::FileLocked)));
     }
+
+    /// Creating over an existing file returns an I/O error.
+    #[test]
+    fn create_existing_file_returns_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("test.bale");
+        std::fs::write(&path, b"existing").unwrap();
+        let result = MappedArchiveMut::create(&path);
+        assert!(result.is_err());
+    }
+
+    /// `create_with_capacity` sets the initial capacity correctly.
+    #[test]
+    fn capacity_matches_initial_allocation() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("test.bale");
+        let archive = MappedArchiveMut::create_with_capacity(&path, 8192).unwrap();
+        assert_eq!(archive.capacity(), 8192);
+        assert_eq!(archive.len(), 0);
+    }
+
+    /// Extending beyond initial capacity triggers reallocation.
+    #[test]
+    fn extend_grows_beyond_initial_capacity() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("test.bale");
+        let mut archive = MappedArchiveMut::create_with_capacity(&path, 16).unwrap();
+        let data = vec![0xABu8; 64];
+        archive.extend(&data).unwrap();
+        assert_eq!(archive.len(), 64);
+        assert!(archive.capacity() >= 64);
+        assert_eq!(archive.as_bytes(), data.as_slice());
+    }
+
+    /// Growing via `set_len` zero-fills the new region.
+    #[test]
+    fn set_len_extends_with_zeros() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("test.bale");
+        let mut archive = MappedArchiveMut::create_with_capacity(&path, 256).unwrap();
+        archive.extend(b"hi").unwrap();
+        archive.set_len(10).unwrap();
+        assert_eq!(archive.len(), 10);
+        assert_eq!(&archive.as_bytes()[..2], b"hi");
+        assert!(archive.as_bytes()[2..].iter().all(|&b| b == 0));
+    }
+
+    /// Shrinking via `set_len` reduces the logical length.
+    #[test]
+    fn set_len_truncates_logical_length() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("test.bale");
+        let mut archive = MappedArchiveMut::create_with_capacity(&path, 256).unwrap();
+        archive.extend(b"hello world").unwrap();
+        assert_eq!(archive.len(), 11);
+        archive.set_len(5).unwrap();
+        assert_eq!(archive.len(), 5);
+        assert_eq!(archive.as_bytes(), b"hello");
+    }
+
+    /// In-place byte modification via `as_bytes_mut` works.
+    #[test]
+    fn as_bytes_mut_allows_modification() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("test.bale");
+        let mut archive = MappedArchiveMut::create_with_capacity(&path, 256).unwrap();
+        archive.extend(b"hello").unwrap();
+        archive.as_bytes_mut()[0] = b'H';
+        assert_eq!(archive.as_bytes(), b"Hello");
+    }
+
+    /// `sync` truncates the file to the logical length.
+    #[test]
+    fn sync_updates_file_size() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("test.bale");
+        let mut archive = MappedArchiveMut::create_with_capacity(&path, 4096).unwrap();
+        archive.extend(b"small data").unwrap();
+        archive.sync().unwrap();
+        assert_eq!(archive.capacity(), archive.len());
+        let metadata = std::fs::metadata(&path).unwrap();
+        assert_eq!(metadata.len(), 10);
+    }
+
+    /// Drop preserves `max(len, committed_len)`.
+    #[test]
+    fn drop_preserves_committed_length() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("test.bale");
+        {
+            let mut archive = MappedArchiveMut::create_with_capacity(&path, 4096).unwrap();
+            archive.extend(b"committed content").unwrap();
+            archive.sync().unwrap();
+            // Reduce logical length below committed length.
+            archive.set_len(5).unwrap();
+            // On drop, file should be truncated to max(5, 17) = 17.
+        }
+        let metadata = std::fs::metadata(&path).unwrap();
+        assert_eq!(metadata.len(), 17);
+    }
 }


### PR DESCRIPTION
## Summary
- Add 32 new unit tests across `crc.rs`, `entry_row.rs`, `mapped_archive_mut.rs`, `writer.rs`, and `compact.rs`
- Covers boundary values, error paths, round-trip serialization, and edge cases
- Overall line coverage improved from 88.52% to 89.20%

## Test plan
- [x] `cargo nextest run` — all 378 tests pass
- [x] `cargo clippy --all-features` — no warnings
- [x] `cargo fmt --check` — clean

Closes #193