### PR TITLE
Replace unreachable!() with error return in symlink resolution

### DIFF
--- a/src/archive/archive_read.rs
+++ b/src/archive/archive_read.rs
@@ -308,7 +308,9 @@ pub trait ArchiveRead {
                 }
             }
 
-            unreachable!("component walk exhausted without returning");
+            return Err(BaleError::Corrupted(
+                "component walk exhausted without returning".into(),
+            ));
         }
     }
 }


### PR DESCRIPTION
## Summary
- Replaced `unreachable!()` macro in symlink resolution loop (`archive_read.rs`) with a `BaleError::Corrupted` error return
- Ensures the library never panics on this code path, even if theoretically unreachable

## Test plan
- [x] All 378 existing tests pass
- [x] All pre-commit hooks pass (clippy, fmt, tests)

Closes #190