### PR TITLE
Fix extract command for directories, symlinks, and add --flat flag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -95,6 +95,7 @@ dependencies = [
  "chrono",
  "clap",
  "crc32c",
+ "dialoguer",
  "env_logger",
  "fs4",
  "fuser",
@@ -218,6 +219,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
+name = "console"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03e45a4a8926227e4197636ba97a9fc9b00477e9f4bd711395687c5f0734bec4"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "once_cell",
+ "unicode-width",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "content_inspector"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -267,6 +281,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "dialoguer"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25f104b501bf2364e78d0d3974cbc774f738f5865306ed128e1e0d7499c0ad96"
+dependencies = [
+ "console",
+ "shell-words",
+ "tempfile",
+ "zeroize",
+]
+
+[[package]]
 name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -277,6 +303,12 @@ name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "env_filter"
@@ -880,6 +912,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shell-words"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1046,6 +1084,12 @@ name = "unicode-ident"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
 name = "utf8parse"
@@ -1235,6 +1279,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
 name = "windows-targets"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1397,3 +1450,9 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,9 +29,9 @@ default = ["bin"]
 reader = []
 writer = []
 compact = ["reader", "writer"]
-cli = ["reader", "writer", "dep:clap", "dep:env_logger"]
+cli = ["compact", "reader", "writer", "dep:clap", "dep:env_logger", "dep:dialoguer"]
 fuse = ["cli", "dep:fuser"]
-bin = ["compact", "fuse"]
+bin = ["fuse"]
 # Enable integration tests requiring external tools (zipinfo, unzip, file, fusermount).
 integration-tests = []
 
@@ -56,6 +56,7 @@ memmap2 = "0.9.9"
 
 # CLI (optional)
 clap = { version = "4", features = ["derive"], optional = true }
+dialoguer = { version = "0.12.0", optional = true }
 
 # FUSE (optional)
 fuser = { version = "0.16.0", optional = true }

--- a/src/bin/bale/cli.rs
+++ b/src/bin/bale/cli.rs
@@ -74,6 +74,9 @@ pub enum Command {
         /// Output directory (defaults to current directory).
         #[arg(short, long, default_value = ".")]
         output: PathBuf,
+        /// Extract without directory structure (flatten paths).
+        #[arg(long, visible_alias = "flatten")]
+        flat: bool,
         /// Entries to extract (if empty, extracts all).
         entries: Vec<String>,
     },

--- a/src/bin/bale/commands/extract.rs
+++ b/src/bin/bale/commands/extract.rs
@@ -3,10 +3,11 @@
 use std::collections::HashSet;
 use std::fs::{self, File};
 use std::io::Write;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use bale::format::EntryRow;
-use bale::{ArchivePath, ArchiveRead, ArchiveReader, BaleError};
+use bale::{ArchivePath, ArchiveRead, ArchiveReader, BaleError, EntryKind};
+use dialoguer::Confirm;
 
 use crate::error::BaleCliError;
 
@@ -15,10 +16,20 @@ use crate::error::BaleCliError;
 /// If no entries are specified, extracts all entries. Paths are validated
 /// via `ArchivePath::normalize()` which rejects traversal attempts (e.g.,
 /// `../../../etc/passwd`) and produces safe relative paths.
+///
+/// When `flat` is true, directory components are stripped so all files
+/// are extracted directly into the output directory. Directory entries
+/// are skipped in flat mode.
+///
+/// # Errors
+///
+/// Returns an error if the archive cannot be opened, an entry cannot be
+/// read, or file I/O fails during extraction.
 pub fn run(
     archive_path: impl AsRef<Path>,
     output_dir: impl AsRef<Path>,
     entries: &[String],
+    flat: bool,
 ) -> Result<(), BaleCliError> {
     let reader = ArchiveReader::open(archive_path)?;
     let output_dir = output_dir.as_ref();
@@ -29,7 +40,7 @@ pub fn run(
     if entries.is_empty() {
         // Extract all entries in a single pass.
         for (entry_row, path_bytes) in reader.iter_entries() {
-            extract_entry(&reader, entry_row, path_bytes, output_dir)?;
+            extract_entry(&reader, entry_row, path_bytes, output_dir, flat)?;
         }
     } else {
         // Build set of requested paths for O(1) lookup.
@@ -41,7 +52,7 @@ pub fn run(
             if let Some(path_str) = archive_path.as_str()
                 && requested.remove(path_str)
             {
-                extract_entry(&reader, entry_row, path_bytes, output_dir)?;
+                extract_entry(&reader, entry_row, path_bytes, output_dir, flat)?;
             }
         }
 
@@ -54,17 +65,20 @@ pub fn run(
     Ok(())
 }
 
-/// Extracts a single entry to the output directory.
+/// Resolves the destination path for an entry, applying flat mode if requested.
 ///
-/// Uses `ArchivePath::normalize()` to validate paths. This rejects any path
-/// that attempts to escape via `..` components and ensures the result is a
-/// safe relative path (no leading slashes, no `..` components).
-fn extract_entry(
-    reader: &ArchiveReader,
-    entry_row: &EntryRow,
+/// In flat mode, only the file name component is used (directory structure
+/// is stripped). Returns `None` for directory entries in flat mode since
+/// they have no meaningful file to extract.
+///
+/// # Errors
+///
+/// Returns an error if the path cannot be normalized or converted to UTF-8.
+fn resolve_dest_path(
     path_bytes: &[u8],
     output_dir: &Path,
-) -> Result<(), BaleCliError> {
+    flat: bool,
+) -> Result<Option<(PathBuf, String)>, BaleCliError> {
     let archive_path = ArchivePath::from_null_padded_bytes(path_bytes);
 
     // Normalize path: validates UTF-8, rejects `..` traversal, removes
@@ -74,8 +88,118 @@ fn extract_entry(
         .as_str()
         .ok_or_else(|| BaleError::InvalidPath(format!("{path_bytes:?}")))?;
 
-    let dest_path = output_dir.join(path_str);
+    if flat {
+        // In flat mode, use only the file name component.
+        let file_name = Path::new(path_str)
+            .file_name()
+            .and_then(|n| n.to_str())
+            .map(String::from);
 
+        match file_name {
+            Some(name) => {
+                let dest_path = output_dir.join(&name);
+                Ok(Some((dest_path, name)))
+            }
+            // Directory entries (e.g., "dir/") have no file name; skip them.
+            None => Ok(None),
+        }
+    } else {
+        let dest_path = output_dir.join(path_str);
+        Ok(Some((dest_path, path_str.to_string())))
+    }
+}
+
+/// Prompts the user to confirm overwriting an existing file.
+///
+/// Returns `true` if the user confirms, `false` if declined.
+/// When no interactive terminal is available (e.g., piped input),
+/// defaults to `false` and logs a warning.
+///
+/// # Errors
+///
+/// Returns an error if the terminal prompt fails unexpectedly.
+fn confirm_overwrite(path_str: &str) -> Result<bool, BaleCliError> {
+    match Confirm::new()
+        .with_prompt(format!("overwrite '{path_str}'?"))
+        .default(false)
+        .interact()
+    {
+        Ok(confirmed) => Ok(confirmed),
+        Err(_) => {
+            // No interactive terminal — default to keeping existing file.
+            log::warn!("no terminal for overwrite prompt, keeping existing '{path_str}'");
+            Ok(false)
+        }
+    }
+}
+
+/// Extracts a single entry to the output directory.
+///
+/// Handles files, directories, and symlinks based on the entry kind.
+/// In flat mode, directory components are stripped and directory entries
+/// are skipped. Prompts before overwriting existing files.
+///
+/// # Errors
+///
+/// Returns an error if paths cannot be resolved, data cannot be read,
+/// or file system operations fail.
+fn extract_entry(
+    reader: &ArchiveReader,
+    entry_row: &EntryRow,
+    path_bytes: &[u8],
+    output_dir: &Path,
+    flat: bool,
+) -> Result<(), BaleCliError> {
+    let kind = entry_row.kind();
+
+    // In flat mode, skip directory entries entirely.
+    if flat && kind.is_directory() {
+        return Ok(());
+    }
+
+    let Some((dest_path, display_path)) = resolve_dest_path(path_bytes, output_dir, flat)? else {
+        // No usable file name (e.g., root directory in flat mode).
+        return Ok(());
+    };
+
+    // Check for existing file and prompt before overwriting.
+    if dest_path.exists() && !confirm_overwrite(&display_path)? {
+        #[allow(clippy::print_stdout)]
+        {
+            println!("  skipped: {display_path}");
+        }
+        return Ok(());
+    }
+
+    match kind {
+        EntryKind::File => extract_file(reader, entry_row, &dest_path, &display_path)?,
+        EntryKind::Directory => extract_directory(entry_row, &dest_path, &display_path)?,
+        EntryKind::Symlink => extract_symlink(reader, entry_row, &dest_path, &display_path)?,
+        EntryKind::Other(mode) => {
+            #[allow(clippy::print_stdout)]
+            {
+                println!("  skipped (unsupported type {mode:#o}): {display_path}");
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Extracts a regular file entry.
+///
+/// Creates parent directories, writes file data, and sets Unix permissions.
+///
+/// # Errors
+///
+/// Returns an error if directories cannot be created, data cannot be read,
+/// or the file cannot be written.
+fn extract_file(
+    reader: &ArchiveReader,
+    entry_row: &EntryRow,
+    dest_path: &Path,
+    display_path: &str,
+) -> Result<(), BaleCliError> {
     // Create parent directories.
     if let Some(parent) = dest_path.parent() {
         fs::create_dir_all(parent)?;
@@ -83,22 +207,123 @@ fn extract_entry(
 
     // Read and write data.
     let data = reader.read_data(entry_row)?;
-    let mut file = File::create(&dest_path)?;
+    let mut file = File::create(dest_path)?;
     file.write_all(data)?;
 
     // Set permissions on Unix.
+    set_permissions(entry_row, dest_path)?;
+
+    #[allow(clippy::print_stdout)]
+    {
+        println!("  extracted: {display_path}");
+    }
+
+    Ok(())
+}
+
+/// Extracts a directory entry.
+///
+/// Creates the directory and all parent directories, then sets Unix permissions.
+///
+/// # Errors
+///
+/// Returns an error if the directory cannot be created.
+fn extract_directory(
+    entry_row: &EntryRow,
+    dest_path: &Path,
+    display_path: &str,
+) -> Result<(), BaleCliError> {
+    fs::create_dir_all(dest_path)?;
+
+    // Set permissions on Unix.
+    set_permissions(entry_row, dest_path)?;
+
+    #[allow(clippy::print_stdout)]
+    {
+        println!("  extracted: {display_path}");
+    }
+
+    Ok(())
+}
+
+/// Extracts a symlink entry.
+///
+/// Reads the symlink target from the entry data and creates a symbolic link.
+/// On non-Unix platforms, prints a warning and skips the entry.
+///
+/// # Errors
+///
+/// Returns an error if the target path is not valid UTF-8, parent
+/// directories cannot be created, or the symlink cannot be created.
+fn extract_symlink(
+    reader: &ArchiveReader,
+    entry_row: &EntryRow,
+    dest_path: &Path,
+    display_path: &str,
+) -> Result<(), BaleCliError> {
+    let data = reader.read_data(entry_row)?;
+    let target = std::str::from_utf8(data)
+        .map_err(|_| BaleError::InvalidPath(format!("symlink target for '{display_path}'")))?;
+
+    #[cfg(unix)]
+    {
+        // Create parent directories.
+        if let Some(parent) = dest_path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+
+        // Remove existing path if it's a symlink (exists() returns false
+        // for broken symlinks, but symlink_metadata catches them).
+        if dest_path.symlink_metadata().is_ok() {
+            fs::remove_file(dest_path)?;
+        }
+
+        std::os::unix::fs::symlink(target, dest_path)?;
+
+        // Skip set_permissions for symlinks: Unix doesn't broadly support
+        // lchmod, and symlink permissions follow the target.
+
+        #[allow(clippy::print_stdout)]
+        {
+            println!("  extracted: {display_path} -> {target}");
+        }
+    }
+
+    #[cfg(not(unix))]
+    {
+        let _ = (dest_path, target);
+        #[allow(clippy::print_stdout)]
+        {
+            println!("  skipped (symlinks not supported on this platform): {display_path}");
+        }
+    }
+
+    Ok(())
+}
+
+/// Sets Unix file permissions from the entry mode bits.
+///
+/// Only the permission bits (lower 12 bits) are applied, skipping
+/// entries with mode 0 (unset). This is a no-op on non-Unix platforms.
+///
+/// # Errors
+///
+/// Returns an error if permissions cannot be set.
+fn set_permissions(entry_row: &EntryRow, dest_path: &Path) -> Result<(), BaleCliError> {
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
         let mode = entry_row.mode.get();
         if mode != 0 {
-            fs::set_permissions(&dest_path, fs::Permissions::from_mode(mode))?;
+            // Apply only permission bits (mask out file type bits).
+            let perm_bits = mode & 0o7777;
+            fs::set_permissions(dest_path, fs::Permissions::from_mode(perm_bits))?;
         }
     }
 
-    #[allow(clippy::print_stdout)]
+    #[cfg(not(unix))]
     {
-        println!("  extracted: {path_str}");
+        let _ = (entry_row, dest_path);
     }
 
     Ok(())

--- a/src/bin/bale/main.rs
+++ b/src/bin/bale/main.rs
@@ -87,8 +87,9 @@ fn run(cli: Cli) -> Result<(), BaleCliError> {
         Command::Extract {
             archive,
             output,
+            flat,
             entries,
-        } => commands::extract::run(archive, output, &entries),
+        } => commands::extract::run(archive, output, &entries, flat),
 
         // Maintenance.
         #[cfg(feature = "compact")]

--- a/tests/cli_commands.rs
+++ b/tests/cli_commands.rs
@@ -5,6 +5,7 @@
 use std::fs;
 use std::process::Command;
 
+use bale::{ArchiveWrite, ArchiveWriter};
 use tempfile::tempdir;
 
 /// Helper to run bale command and return (success, stdout, stderr).
@@ -248,5 +249,227 @@ fn compact_archive() {
     assert!(
         size_after < size_before,
         "archive should be smaller after compact"
+    );
+}
+
+/// Helper to create an archive with a directory entry via the library API.
+fn create_archive_with_directory(archive_path: &std::path::Path) {
+    let mut writer = ArchiveWriter::create(archive_path).unwrap();
+    // Add a directory entry (mode 0o040755 = directory with rwxr-xr-x).
+    writer.add_entry("mydir", b"", 0o040755).unwrap();
+    // Add a file inside the directory.
+    writer
+        .add_entry("mydir/hello.txt", b"Hello!", 0o100644)
+        .unwrap();
+    writer.sync().unwrap();
+}
+
+/// Helper to create an archive with a symlink entry via the library API.
+fn create_archive_with_symlink(archive_path: &std::path::Path) {
+    let mut writer = ArchiveWriter::create(archive_path).unwrap();
+    // Add a regular file.
+    writer
+        .add_entry("target.txt", b"link target content", 0o100644)
+        .unwrap();
+    // Add a symlink: data is the target path, mode 0o120777 = symlink.
+    writer
+        .add_entry("link.txt", b"target.txt", 0o120777)
+        .unwrap();
+    writer.sync().unwrap();
+}
+
+/// Extract creates directories from directory entries.
+#[test]
+fn extract_creates_directories() {
+    let dir = tempdir().unwrap();
+    let archive = dir.path().join("test.bale");
+    let out_dir = dir.path().join("output");
+
+    create_archive_with_directory(&archive);
+
+    let (success, stdout, stderr) = run_bale(&[
+        "extract",
+        archive.to_str().unwrap(),
+        "-o",
+        out_dir.to_str().unwrap(),
+    ]);
+    assert!(success, "extract should succeed: {stderr}");
+    assert!(stdout.contains("extracted: mydir"), "should extract dir");
+    assert!(
+        stdout.contains("extracted: mydir/hello.txt"),
+        "should extract file"
+    );
+
+    // Verify directory was created.
+    assert!(
+        out_dir.join("mydir").is_dir(),
+        "mydir should be a directory"
+    );
+    // Verify file inside directory.
+    assert_eq!(
+        fs::read_to_string(out_dir.join("mydir/hello.txt")).unwrap(),
+        "Hello!"
+    );
+}
+
+/// Extract creates symlinks from symlink entries.
+#[cfg(unix)]
+#[test]
+fn extract_creates_symlinks() {
+    let dir = tempdir().unwrap();
+    let archive = dir.path().join("test.bale");
+    let out_dir = dir.path().join("output");
+
+    create_archive_with_symlink(&archive);
+
+    let (success, stdout, stderr) = run_bale(&[
+        "extract",
+        archive.to_str().unwrap(),
+        "-o",
+        out_dir.to_str().unwrap(),
+    ]);
+    assert!(success, "extract should succeed: {stderr}");
+    assert!(
+        stdout.contains("extracted: link.txt -> target.txt"),
+        "should show symlink target in output, got: {stdout}"
+    );
+
+    // Verify the symlink was created.
+    let link = out_dir.join("link.txt");
+    assert!(
+        link.symlink_metadata().unwrap().file_type().is_symlink(),
+        "link.txt should be a symlink"
+    );
+    assert_eq!(
+        fs::read_link(&link).unwrap().to_str().unwrap(),
+        "target.txt"
+    );
+    // Verify reading through the symlink works.
+    assert_eq!(fs::read_to_string(&link).unwrap(), "link target content");
+}
+
+/// Extract with --flat strips directory components.
+#[test]
+fn extract_flat_strips_directories() {
+    let dir = tempdir().unwrap();
+    let archive = dir.path().join("test.bale");
+    let out_dir = dir.path().join("output");
+
+    create_archive_with_directory(&archive);
+
+    let (success, stdout, stderr) = run_bale(&[
+        "extract",
+        archive.to_str().unwrap(),
+        "-o",
+        out_dir.to_str().unwrap(),
+        "--flat",
+    ]);
+    assert!(success, "extract --flat should succeed: {stderr}");
+
+    // File should be extracted directly into output dir (no mydir/ prefix).
+    let extracted = out_dir.join("hello.txt");
+    assert!(
+        extracted.exists(),
+        "hello.txt should exist directly in output: {stdout}"
+    );
+    assert_eq!(fs::read_to_string(&extracted).unwrap(), "Hello!");
+
+    // Directory entry should be skipped in flat mode.
+    assert!(
+        !out_dir.join("mydir").exists(),
+        "directory entry should not be created in flat mode"
+    );
+}
+
+/// Extract with --flat skips directory entries.
+#[test]
+fn extract_flat_skips_directory_entries() {
+    let dir = tempdir().unwrap();
+    let archive = dir.path().join("test.bale");
+    let out_dir = dir.path().join("output");
+
+    // Create archive with only a directory entry.
+    {
+        let mut writer = ArchiveWriter::create(&archive).unwrap();
+        writer.add_entry("emptydir", b"", 0o040755).unwrap();
+        writer.sync().unwrap();
+    }
+
+    let (success, stdout, _) = run_bale(&[
+        "extract",
+        archive.to_str().unwrap(),
+        "-o",
+        out_dir.to_str().unwrap(),
+        "--flat",
+    ]);
+    assert!(success, "extract --flat should succeed");
+    // No files should be extracted.
+    assert!(
+        !stdout.contains("extracted:"),
+        "no entries should be extracted in flat mode for directory-only archive, got: {stdout}"
+    );
+}
+
+/// Extract with --flatten alias works (visible alias for --flat).
+#[test]
+fn extract_flatten_alias_works() {
+    let dir = tempdir().unwrap();
+    let archive = dir.path().join("test.bale");
+    let file1 = dir.path().join("hello.txt");
+    let out_dir = dir.path().join("output");
+
+    fs::write(&file1, "Hello!").unwrap();
+
+    run_bale(&["touch", archive.to_str().unwrap()]);
+    run_bale(&["add", archive.to_str().unwrap(), file1.to_str().unwrap()]);
+
+    let (success, _, stderr) = run_bale(&[
+        "extract",
+        archive.to_str().unwrap(),
+        "-o",
+        out_dir.to_str().unwrap(),
+        "--flatten",
+    ]);
+    assert!(success, "extract --flatten alias should succeed: {stderr}");
+    assert!(out_dir.join("hello.txt").exists());
+}
+
+/// Extract skips existing files in non-interactive mode (no overwrite prompt).
+#[test]
+fn extract_skips_existing_in_non_interactive() {
+    let dir = tempdir().unwrap();
+    let archive = dir.path().join("test.bale");
+    let out_dir = dir.path().join("output");
+
+    // Create archive with a file.
+    {
+        let mut writer = ArchiveWriter::create(&archive).unwrap();
+        writer
+            .add_entry("existing.txt", b"new content", 0o100644)
+            .unwrap();
+        writer.sync().unwrap();
+    }
+
+    // Pre-create the file with different content.
+    fs::create_dir_all(&out_dir).unwrap();
+    fs::write(out_dir.join("existing.txt"), "original content").unwrap();
+
+    // Extract (non-interactive, so overwrite prompt defaults to "no").
+    let (success, stdout, _) = run_bale(&[
+        "extract",
+        archive.to_str().unwrap(),
+        "-o",
+        out_dir.to_str().unwrap(),
+    ]);
+    assert!(success, "extract should succeed");
+    assert!(
+        stdout.contains("skipped: existing.txt"),
+        "should report skipped file, got: {stdout}"
+    );
+
+    // Original content should be preserved.
+    assert_eq!(
+        fs::read_to_string(out_dir.join("existing.txt")).unwrap(),
+        "original content"
     );
 }


### PR DESCRIPTION
## Summary

Closes #188.

- Extract now handles entry types correctly: directories are created with `create_dir_all`, symlinks are created with `std::os::unix::fs::symlink` (skipped with warning on non-Unix), and unknown types are skipped with a warning
- Adds `--flat` / `--flatten` flag to strip directory components during extraction (directory entries are skipped in flat mode)
- Adds overwrite prompts via `dialoguer::Confirm`; defaults to skip (keep existing) when no interactive terminal is available
- Masks file type bits when setting permissions (applies only permission bits `0o7777`)
- Moves `compact` feature from `bin` into `cli` where it belongs
- Adds 6 integration tests covering directories, symlinks, flat mode, alias, and non-interactive overwrite behavior

## Test plan

- [x] `cargo nextest run` — 384 tests pass
- [x] `cargo clippy` — clean
- [x] `git precommit --all` — all hooks pass
- [x] Manual: create archive with files, dirs, symlinks; extract normally; extract with `--flat`; verify results
- [x] Manual: extract over existing files; verify overwrite prompt appears interactively