### PR TITLE
Rename folder() to directory() for API consistency

### DIFF
--- a/src/archive/archive_read.rs
+++ b/src/archive/archive_read.rs
@@ -189,7 +189,7 @@ pub trait ArchiveRead {
     /// Returns an error if:
     /// - The path is not found ([`BaleError::EntryNotFound`])
     /// - The entry exists but is not a directory ([`BaleError::NotADirectory`])
-    fn folder(&self, path: impl AsRef<str>) -> Result<DirEntry<'_>, BaleError>;
+    fn directory(&self, path: impl AsRef<str>) -> Result<DirEntry<'_>, BaleError>;
 
     /// Returns a symlink entry by path.
     ///

--- a/src/archive/archive_write.rs
+++ b/src/archive/archive_write.rs
@@ -176,7 +176,7 @@ pub trait ArchiveWrite: ArchiveRead {
     /// Returns an error if:
     /// - The path exceeds the archive's path_size
     /// - Writing to the archive fails
-    fn add_folder(&mut self, path: impl AsRef<str>, mode: u32) -> Result<(), BaleError>;
+    fn add_directory(&mut self, path: impl AsRef<str>, mode: u32) -> Result<(), BaleError>;
 
     /// Creates a symbolic link entry.
     ///

--- a/src/archive/entry.rs
+++ b/src/archive/entry.rs
@@ -6,7 +6,7 @@ use crate::archive::{DirEntry, FileEntry, SymlinkEntry};
 ///
 /// This enum provides generic access to archive entries when the caller
 /// needs to handle any entry type. For type-specific access, use
-/// [`ArchiveRead::file`], [`ArchiveRead::folder`], or the entry's
+/// [`ArchiveRead::file`], [`ArchiveRead::directory`], or the entry's
 /// conversion methods.
 ///
 /// # Example

--- a/src/archive/reader.rs
+++ b/src/archive/reader.rs
@@ -498,7 +498,7 @@ impl ArchiveRead for Archive<MappedArchive> {
     /// # Errors
     ///
     /// Returns an error if the path is not found or is not a directory.
-    fn folder(&self, path: impl AsRef<str>) -> Result<DirEntry<'_>, BaleError> {
+    fn directory(&self, path: impl AsRef<str>) -> Result<DirEntry<'_>, BaleError> {
         let path = path.as_ref();
         let (entry, path_bytes, id) = self
             .find_entry_with_path(path)
@@ -1096,9 +1096,9 @@ mod tests {
         assert!(matches!(result, Err(BaleError::NotAFile(_))));
     }
 
-    /// folder() returns a DirEntry for directories.
+    /// directory() returns a DirEntry for directories.
     #[test]
-    fn folder_accessor() {
+    fn directory_accessor() {
         let bytes = build_test_archive(&[TestEntry {
             path: "src",
             data: b"",
@@ -1107,14 +1107,14 @@ mod tests {
         }]);
         let archive = archive_from_bytes(&bytes);
 
-        let dir = archive.folder("src").unwrap();
+        let dir = archive.directory("src").unwrap();
         assert_eq!(dir.path().as_str(), Some("src"));
         assert_eq!(dir.id(), 1);
     }
 
-    /// folder() on a file returns NotADirectory.
+    /// directory() on a file returns NotADirectory.
     #[test]
-    fn folder_on_file_returns_not_a_directory() {
+    fn directory_on_file_returns_not_a_directory() {
         let bytes = build_test_archive(&[TestEntry {
             path: "file.txt",
             data: b"data",
@@ -1123,7 +1123,7 @@ mod tests {
         }]);
         let archive = archive_from_bytes(&bytes);
 
-        let result = archive.folder("file.txt");
+        let result = archive.directory("file.txt");
         assert!(matches!(result, Err(BaleError::NotADirectory(_))));
     }
 

--- a/src/archive/writer.rs
+++ b/src/archive/writer.rs
@@ -523,7 +523,7 @@ impl ArchiveRead for Archive<MappedArchiveMut> {
     /// # Errors
     ///
     /// Returns an error if not found or not a directory.
-    fn folder(&self, path: impl AsRef<str>) -> Result<DirEntry<'_>, BaleError> {
+    fn directory(&self, path: impl AsRef<str>) -> Result<DirEntry<'_>, BaleError> {
         let path = path.as_ref();
         let (entry, path_bytes, id) = self
             .find_entry_with_path(path)
@@ -987,7 +987,7 @@ impl ArchiveWrite for Archive<MappedArchiveMut> {
     /// # Errors
     ///
     /// Returns an error if the path is invalid or writing fails.
-    fn add_folder(&mut self, path: impl AsRef<str>, mode: u32) -> Result<(), BaleError> {
+    fn add_directory(&mut self, path: impl AsRef<str>, mode: u32) -> Result<(), BaleError> {
         let path = path.as_ref();
         // Ensure directory type bits are set.
         let mode = if mode & SFlag::S_IFMT.bits() == 0 {
@@ -1165,15 +1165,15 @@ mod tests {
         assert_eq!(entry.kind(), EntryKind::File);
     }
 
-    /// add_folder creates a directory entry with no data.
+    /// add_directory creates a directory entry with no data.
     #[test]
-    fn add_folder_creates_directory() {
+    fn add_directory_creates_directory() {
         let dir = TempDir::new().unwrap();
         let path = dir.path().join("test.bale");
 
         {
             let mut writer = ArchiveWriter::create(&path).unwrap();
-            writer.add_folder("mydir", 0o755).unwrap();
+            writer.add_directory("mydir", 0o755).unwrap();
             writer.sync().unwrap();
         }
 
@@ -1183,7 +1183,7 @@ mod tests {
         assert_eq!(entry.data_offset.get(), 0);
         assert_eq!(entry.file_size.get(), 0);
 
-        let dir_entry = reader.folder("mydir").unwrap();
+        let dir_entry = reader.directory("mydir").unwrap();
         assert_eq!(dir_entry.path().as_str(), Some("mydir"));
     }
 
@@ -1354,7 +1354,7 @@ mod tests {
         writer.sync().unwrap();
     }
 
-    /// Writer entry/file/folder/symlink accessors work.
+    /// Writer entry/file/directory/symlink accessors work.
     #[test]
     fn writer_typed_accessors() {
         let dir = TempDir::new().unwrap();
@@ -1362,7 +1362,7 @@ mod tests {
 
         let mut writer = ArchiveWriter::create(&path).unwrap();
         writer.add_entry("a_file.txt", b"data", 0o100644).unwrap();
-        writer.add_folder("a_dir", 0o755).unwrap();
+        writer.add_directory("a_dir", 0o755).unwrap();
         writer.add_symlink("a_link", "target", 0o777).unwrap();
 
         assert!(writer.entry("a_file.txt").unwrap().is_file());
@@ -1370,7 +1370,7 @@ mod tests {
         assert!(writer.entry("a_link").unwrap().is_symlink());
 
         assert!(writer.file("a_file.txt").is_ok());
-        assert!(writer.folder("a_dir").is_ok());
+        assert!(writer.directory("a_dir").is_ok());
         assert!(writer.symlink("a_link").is_ok());
 
         writer.sync().unwrap();
@@ -1447,7 +1447,7 @@ mod tests {
         let path = dir.path().join("test.bale");
 
         let mut writer = ArchiveWriter::create(&path).unwrap();
-        writer.add_folder("mydir", 0o755).unwrap();
+        writer.add_directory("mydir", 0o755).unwrap();
 
         let result = writer.hard_link("mydir", "link");
         assert!(matches!(result, Err(BaleError::NotAFile(_))));
@@ -1544,7 +1544,7 @@ mod tests {
 
         {
             let mut writer = ArchiveWriter::create(&path).unwrap();
-            writer.add_folder("src", 0o755).unwrap();
+            writer.add_directory("src", 0o755).unwrap();
             writer.add_entry("src/a.txt", b"aaa", 0o100644).unwrap();
             writer.add_entry("src/b.txt", b"bbb", 0o100644).unwrap();
             writer.rename("src", "dst").unwrap();
@@ -1555,7 +1555,7 @@ mod tests {
         assert!(reader.find_entry("src").is_none());
         assert!(reader.find_entry("src/a.txt").is_none());
         assert!(reader.find_entry("src/b.txt").is_none());
-        assert!(reader.folder("dst").is_ok());
+        assert!(reader.directory("dst").is_ok());
         assert_eq!(reader.file("dst/a.txt").unwrap().data, b"aaa");
         assert_eq!(reader.file("dst/b.txt").unwrap().data, b"bbb");
     }
@@ -1582,7 +1582,7 @@ mod tests {
 
         // Create archive with small path_size.
         let mut writer = ArchiveWriter::create_with_options(&path, 4096, 16).unwrap();
-        writer.add_folder("a", 0o755).unwrap();
+        writer.add_directory("a", 0o755).unwrap();
         writer.add_entry("a/file.txt", b"data", 0o100644).unwrap();
 
         // Renaming "a" to a long name would make "a/file.txt" exceed 16 bytes.
@@ -1692,7 +1692,7 @@ mod tests {
         let path = dir.path().join("test.bale");
 
         let mut writer = ArchiveWriter::create(&path).unwrap();
-        writer.add_folder("mydir", 0o755).unwrap();
+        writer.add_directory("mydir", 0o755).unwrap();
 
         let result = writer.replace_content("mydir", b"data", 0o100644);
         assert!(matches!(result, Err(BaleError::NotAFile(_))));

--- a/src/archive_path.rs
+++ b/src/archive_path.rs
@@ -10,7 +10,7 @@ use crate::BaleError;
 /// Reserved path prefix for bale internal use.
 ///
 /// Paths with components starting with this prefix are rejected to reserve
-/// space for future format extensions (e.g., virtual `.bale/` metadata folder
+/// space for future format extensions (e.g., virtual `.bale/` metadata directory
 /// in FUSE mounts).
 const RESERVED_PREFIX: &str = ".bale";
 

--- a/src/compact.rs
+++ b/src/compact.rs
@@ -171,7 +171,7 @@ pub fn compact(path: impl AsRef<Path>) -> Result<CompactStats, BaleError> {
         for dir_bytes in &missing_dirs_sorted {
             let dir_str = std::str::from_utf8(dir_bytes)?;
             // Use default directory mode (rwxr-xr-x).
-            writer.add_folder(dir_str, SFlag::S_IFDIR.bits() | DEFAULT_DIR_PERM)?;
+            writer.add_directory(dir_str, SFlag::S_IFDIR.bits() | DEFAULT_DIR_PERM)?;
         }
 
         for (entry_row, path_bytes) in &final_entries {

--- a/src/fuse/bale_fs_state.rs
+++ b/src/fuse/bale_fs_state.rs
@@ -705,7 +705,7 @@ impl BaleFsState {
         // Add directory entry to archive.
         let archive_mode = SFlag::S_IFDIR.bits() | mode.bits();
         self.archive
-            .add_folder(&full_path, archive_mode)
+            .add_directory(&full_path, archive_mode)
             .map_err(|_| libc::EIO)?;
 
         // Update parent directory mtime.
@@ -1282,7 +1282,7 @@ impl BaleFsState {
             }
 
             // Update archive: add new dir entry, remove old.
-            let _ = self.archive.add_folder(&new_path, DEFAULT_DIR_MODE);
+            let _ = self.archive.add_directory(&new_path, DEFAULT_DIR_MODE);
             let _ = self.archive.delete(&old_path);
         }
 


### PR DESCRIPTION
## Summary
- Renames `ArchiveRead::folder()` → `ArchiveRead::directory()` and `ArchiveWrite::add_folder()` → `ArchiveWrite::add_directory()` across the entire codebase
- Updates all implementations (reader, writer), call sites (compact, FUSE), test functions, and doc comments
- Aligns the public API with existing naming conventions (`DirEntry`, `EntryKind::Directory`, `is_directory()`, `as_directory()`, `into_directory()`)

## Test plan
- [x] All 384 existing tests pass
- [x] `cargo clippy` clean
- [x] Pre-commit hooks pass (fmt, clippy, tests, doc tests, no-default-features check)

Closes #191