### PR TITLE
Add proptest fuzz tests for binary format parsing

### DIFF
--- a/src/format/directory_row.rs
+++ b/src/format/directory_row.rs
@@ -158,4 +158,45 @@ mod tests {
         let row = DirectoryRow::from_bytes(&data, path_size).unwrap();
         assert!(row.path().is_err());
     }
+
+    // ==================== Property Tests ====================
+
+    use crate::proptest_config;
+    use proptest::prelude::*;
+
+    proptest! {
+        #![proptest_config(proptest_config::config())]
+
+        /// Arbitrary bytes with correct stride never panic when parsed as a
+        /// DirectoryRow.
+        ///
+        /// Exercises `from_bytes`, `path_bytes`, `path_bytes_raw`, `path`,
+        /// and `entry_id` on random byte patterns with valid path sizes.
+        #[test]
+        fn fuzz_directory_row_correct_stride(
+            path_size in 1u16..=512,
+            data in prop::collection::vec(any::<u8>(), 0..=4100),
+        ) {
+            let stride = DirectoryRow::stride(path_size);
+            if data.len() >= stride {
+                let row = DirectoryRow::from_bytes(&data[..stride], path_size).unwrap();
+                let _ = row.path_bytes_raw();
+                let _ = row.path_bytes();
+                let _ = row.path();
+                let _ = row.entry_id();
+            }
+        }
+
+        /// Wrong-sized slices always return `Err`, never panic.
+        #[test]
+        fn fuzz_directory_row_wrong_size(
+            path_size in 1u16..=512,
+            data in prop::collection::vec(any::<u8>(), 0..=4100),
+        ) {
+            let stride = DirectoryRow::stride(path_size);
+            if data.len() != stride {
+                assert!(DirectoryRow::from_bytes(&data, path_size).is_err());
+            }
+        }
+    }
 }

--- a/src/format/entry_row.rs
+++ b/src/format/entry_row.rs
@@ -285,4 +285,33 @@ mod tests {
         let restored = EntryRow::ref_from_bytes(bytes).unwrap();
         assert_eq!(restored.reserved, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
     }
+
+    // ==================== Property Tests ====================
+
+    use crate::proptest_config;
+    use proptest::prelude::*;
+
+    proptest! {
+        #![proptest_config(proptest_config::config())]
+
+        /// Arbitrary 64-byte input never panics when interpreted as an EntryRow.
+        ///
+        /// Exercises `ref_from_bytes`, `kind`, `crc`, and all accessor methods
+        /// on random byte patterns.
+        #[test]
+        fn fuzz_entry_row_parsing(data in prop::collection::vec(any::<u8>(), 64..=64)) {
+            let row = EntryRow::ref_from_bytes(&data).unwrap();
+            let _ = row.kind();
+            let _ = row.crc();
+            let _ = row.entry_id.get();
+            let _ = row.data_offset.get();
+            let _ = row.file_size.get();
+            let _ = row.block_size.get();
+            let _ = row.created_time.get();
+            let _ = row.modified_time.get();
+            let _ = row.mode.get();
+            let _ = row.compression;
+            let _ = row.flags;
+        }
+    }
 }

--- a/src/format/file_header.rs
+++ b/src/format/file_header.rs
@@ -138,4 +138,24 @@ mod tests {
         assert_eq!(bytes[6], 0); // minor
         assert_eq!(bytes[7], 0); // patch
     }
+
+    // ==================== Property Tests ====================
+
+    use crate::proptest_config;
+    use proptest::prelude::*;
+
+    proptest! {
+        #![proptest_config(proptest_config::config())]
+
+        /// Arbitrary 8-byte input never panics when interpreted as a FileHeader.
+        ///
+        /// Exercises `ref_from_bytes`, `has_valid_magic`, and `version` on
+        /// random byte patterns.
+        #[test]
+        fn fuzz_file_header_parsing(data in prop::collection::vec(any::<u8>(), 8..=8)) {
+            let header = FileHeader::ref_from_bytes(&data).unwrap();
+            let _ = header.has_valid_magic();
+            let _ = header.version();
+        }
+    }
 }

--- a/src/format/trailer.rs
+++ b/src/format/trailer.rs
@@ -637,6 +637,34 @@ mod tests {
         assert!(trailer.validated().is_err());
     }
 
+    // ==================== Property Tests ====================
+
+    use crate::proptest_config;
+    use proptest::prelude::*;
+
+    proptest! {
+        #![proptest_config(proptest_config::config())]
+
+        /// Arbitrary 64-byte input never panics when interpreted as a Trailer.
+        ///
+        /// Exercises `ref_from_bytes`, `is_valid`, `validated`, `has_valid_magic`,
+        /// and `alignment` on random byte patterns.
+        #[test]
+        fn fuzz_trailer_parsing(data in prop::collection::vec(any::<u8>(), 64..=64)) {
+            let trailer = Trailer::ref_from_bytes(&data).unwrap();
+            let _ = trailer.is_valid();
+            let _ = trailer.validated();
+            let _ = trailer.has_valid_magic();
+            let _ = trailer.alignment();
+            let _ = trailer.path_size();
+            let _ = trailer.archive_size();
+            let _ = trailer.next_id();
+            let _ = trailer.flags();
+            let _ = trailer.is_compacted();
+            let _ = trailer.metadata_crc();
+        }
+    }
+
     /// Byte layout matches spec offsets.
     #[test]
     fn byte_layout_matches_spec() {


### PR DESCRIPTION
## Summary

- Add 5 proptest property tests across 4 binary format parser modules to verify they never panic on arbitrary input
- **Trailer** (`trailer.rs`): Fuzz `ref_from_bytes` → `is_valid`, `validated`, `alignment`, and all accessors
- **FileHeader** (`file_header.rs`): Fuzz `ref_from_bytes` → `has_valid_magic`, `version`
- **DirectoryRow** (`directory_row.rs`): Fuzz correct-stride parsing through all accessors; fuzz wrong-sized slices always return `Err`
- **EntryRow** (`entry_row.rs`): Fuzz `ref_from_bytes` → `kind`, `crc`, and all field accessors

Closes #194

## Test plan

- [x] All 5 new property tests pass (`cargo nextest run -E 'test(fuzz_)'`)
- [x] Full test suite passes (389 tests)
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] Pre-commit hooks pass