### PR TITLE
Preserve timestamps during compaction

### DIFF
--- a/src/archive/add_entry_options.rs
+++ b/src/archive/add_entry_options.rs
@@ -1,0 +1,23 @@
+//! Options for adding entries to an archive.
+
+/// Options for adding an entry to an archive.
+///
+/// Controls timestamp behavior when adding entries. By default (all fields
+/// `None`), timestamps are set to the current time — matching the behavior
+/// of [`add_entry`](super::ArchiveWrite::add_entry).
+///
+/// Set `created_time` and/or `modified_time` to `Some(millis)` to override
+/// with specific Unix epoch millisecond values. This is useful for
+/// compaction and other operations that need to preserve original timestamps.
+#[derive(Debug, Clone, Default)]
+pub struct AddEntryOptions {
+    /// Creation timestamp as Unix epoch milliseconds.
+    ///
+    /// When `None`, defaults to the current time.
+    pub created_time: Option<i64>,
+
+    /// Modification timestamp as Unix epoch milliseconds.
+    ///
+    /// When `None`, defaults to the current time.
+    pub modified_time: Option<i64>,
+}

--- a/src/archive/mod.rs
+++ b/src/archive/mod.rs
@@ -9,6 +9,8 @@
 //! - [`ArchiveReader`] = `Archive<MappedArchive>` - Read-only access
 //! - [`ArchiveWriter`] = `Archive<MappedArchiveMut>` - Read-write access
 
+/// Options for adding entries.
+mod add_entry_options;
 /// Read operations trait.
 mod archive_read;
 /// Write operations trait.
@@ -29,6 +31,7 @@ mod symlink_entry;
 /// Read-write archive implementation.
 mod writer;
 
+pub use add_entry_options::AddEntryOptions;
 pub use archive_read::ArchiveRead;
 pub(crate) use archive_read::resolve_target;
 pub use archive_write::ArchiveWrite;

--- a/src/archive/writer.rs
+++ b/src/archive/writer.rs
@@ -5,7 +5,9 @@
 //! tables (`entry_rows`, `dir_entries`) to accumulate entries before flushing
 //! to disk via [`sync()`](ArchiveWrite::sync).
 
-use super::{Archive, ArchiveRead, ArchiveWrite, DirEntry, Entry, FileEntry, SymlinkEntry};
+use super::{
+    AddEntryOptions, Archive, ArchiveRead, ArchiveWrite, DirEntry, Entry, FileEntry, SymlinkEntry,
+};
 use crate::format::{Crc, DirectoryRow, EntryRow, FileHeader, Trailer};
 use crate::{ArchivePath, BaleError, EntryKind, MappedArchiveMut};
 use nix::sys::stat::SFlag;
@@ -153,6 +155,72 @@ impl Archive<MappedArchiveMut> {
             entry_rows,
             dir_entries,
         })
+    }
+
+    /// Adds an entry with configurable options.
+    ///
+    /// This is the most flexible entry-addition method. It accepts
+    /// [`AddEntryOptions`] to control timestamp behavior:
+    ///
+    /// - `created_time: None` → uses the current time
+    /// - `modified_time: None` → uses the current time
+    /// - `Some(millis)` → uses the provided Unix epoch millisecond value
+    ///
+    /// This is useful for compaction and other operations that need to
+    /// preserve original timestamps when re-writing entries.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the path is invalid or writing fails.
+    pub fn add_entry_with_options(
+        &mut self,
+        path: &str,
+        data: &[u8],
+        mode: u32,
+        options: AddEntryOptions,
+    ) -> Result<(), BaleError> {
+        // Validate and normalize path.
+        let normalized = ArchivePath::from_bytes(path.as_bytes()).normalize()?;
+        let normalized_str = normalized
+            .as_str()
+            .ok_or_else(|| BaleError::InvalidPath(path.to_string()))?;
+
+        // Check path fits within path_size.
+        let padded = self.pad_path(normalized_str)?;
+
+        // Assign entry ID, checking for overflow.
+        let entry_id = self.trailer.next_id();
+        if entry_id == u32::MAX {
+            return Err(BaleError::ArchiveFull);
+        }
+        self.trailer.set_next_id(entry_id + 1);
+
+        // Write data block (returns offset and CRC).
+        let (data_offset, crc) = self.write_data_block(data)?;
+
+        // Resolve timestamps, defaulting to now.
+        let now = now_millis();
+        let created_time = options.created_time.unwrap_or(now);
+        let modified_time = options.modified_time.unwrap_or(now);
+
+        // Create entry row with resolved timestamps.
+        let entry_row = EntryRow::new_file(
+            entry_id,
+            crc,
+            data_offset,
+            data.len() as u64,
+            data.len() as u64,
+            created_time,
+            modified_time,
+            mode,
+        );
+
+        // Add to in-memory tables.
+        self.entry_rows.push(entry_row);
+        self.dir_entries.push((padded, entry_id));
+        self.dirty = true;
+
+        Ok(())
     }
 
     /// Null-pads a path to the configured path_size.
@@ -614,45 +682,16 @@ impl ArchiveWrite for Archive<MappedArchiveMut> {
         mode: u32,
         mtime: Option<SystemTime>,
     ) -> Result<(), BaleError> {
-        // Validate and normalize path.
-        let normalized = ArchivePath::from_bytes(path.as_bytes()).normalize()?;
-        let normalized_str = normalized
-            .as_str()
-            .ok_or_else(|| BaleError::InvalidPath(path.to_string()))?;
-
-        // Check path fits within path_size.
-        let padded = self.pad_path(normalized_str)?;
-
-        // Assign entry ID, checking for overflow.
-        let entry_id = self.trailer.next_id();
-        if entry_id == u32::MAX {
-            return Err(BaleError::ArchiveFull);
-        }
-        self.trailer.set_next_id(entry_id + 1);
-
-        // Write data block (returns offset and CRC).
-        let (data_offset, crc) = self.write_data_block(data)?;
-
-        // Create entry row with timestamps.
         let now = now_millis();
-        let modified_time = mtime.map_or(now, system_time_to_millis);
-        let entry_row = EntryRow::new_file(
-            entry_id,
-            crc,
-            data_offset,
-            data.len() as u64,
-            data.len() as u64,
-            now,
-            modified_time,
+        self.add_entry_with_options(
+            path,
+            data,
             mode,
-        );
-
-        // Add to in-memory tables.
-        self.entry_rows.push(entry_row);
-        self.dir_entries.push((padded, entry_id));
-        self.dirty = true;
-
-        Ok(())
+            AddEntryOptions {
+                created_time: Some(now),
+                modified_time: Some(mtime.map_or(now, system_time_to_millis)),
+            },
+        )
     }
 
     /// Adds a file from the filesystem.

--- a/src/compact.rs
+++ b/src/compact.rs
@@ -2,7 +2,8 @@
 
 use crate::format::EntryRow;
 use crate::{
-    ArchivePath, ArchiveRead, ArchiveReader, ArchiveWrite, ArchiveWriter, BaleError, EntryKind,
+    AddEntryOptions, ArchivePath, ArchiveRead, ArchiveReader, ArchiveWrite, ArchiveWriter,
+    BaleError, EntryKind,
 };
 use nix::sys::stat::SFlag;
 use std::collections::{HashMap, HashSet};
@@ -185,7 +186,15 @@ pub fn compact(path: impl AsRef<Path>) -> Result<CompactStats, BaleError> {
             // Get mode from entry row.
             let mode = entry_row.mode.get();
 
-            writer.add_entry(path_str, data, mode)?;
+            writer.add_entry_with_options(
+                path_str,
+                data,
+                mode,
+                AddEntryOptions {
+                    created_time: Some(entry_row.created_time.get()),
+                    modified_time: Some(entry_row.modified_time.get()),
+                },
+            )?;
         }
 
         writer.sync()?;
@@ -313,7 +322,15 @@ pub fn rename_duplicates(path: impl AsRef<Path>) -> Result<RenameStats, BaleErro
         for (entry_row, new_path) in &entries {
             let data = reader.read_data(entry_row)?;
             let mode = entry_row.mode.get();
-            writer.add_entry(new_path, data, mode)?;
+            writer.add_entry_with_options(
+                new_path,
+                data,
+                mode,
+                AddEntryOptions {
+                    created_time: Some(entry_row.created_time.get()),
+                    modified_time: Some(entry_row.modified_time.get()),
+                },
+            )?;
         }
 
         writer.sync()?;
@@ -332,7 +349,10 @@ pub fn rename_duplicates(path: impl AsRef<Path>) -> Result<RenameStats, BaleErro
 #[cfg(test)]
 mod tests {
     use super::*;
+    use proptest::prelude::*;
     use tempfile::TempDir;
+
+    use crate::proptest_config;
 
     /// Compacting an empty archive works.
     #[test]
@@ -748,5 +768,140 @@ mod tests {
                 .unwrap(),
             b"third"
         );
+    }
+
+    /// Compacting preserves created_time and modified_time from original entries.
+    #[test]
+    fn compact_preserves_timestamps() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("test.bale");
+
+        // Create archive with entries and record their timestamps.
+        {
+            let mut writer = ArchiveWriter::create(&path).unwrap();
+            writer.add_entry("a.txt", b"aaa", 0o644).unwrap();
+            writer.add_entry("b.txt", b"bbb", 0o644).unwrap();
+            writer.sync().unwrap();
+        }
+
+        // Read timestamps before compaction.
+        let (a_created, a_modified, b_created, b_modified) = {
+            let reader = ArchiveReader::open(&path).unwrap();
+            let a = reader.find_entry("a.txt").unwrap();
+            let b = reader.find_entry("b.txt").unwrap();
+            (
+                a.created_time.get(),
+                a.modified_time.get(),
+                b.created_time.get(),
+                b.modified_time.get(),
+            )
+        };
+
+        compact(&path).unwrap();
+
+        // Verify timestamps are preserved.
+        let reader = ArchiveReader::open(&path).unwrap();
+        let a = reader.find_entry("a.txt").unwrap();
+        let b = reader.find_entry("b.txt").unwrap();
+
+        assert_eq!(a.created_time.get(), a_created);
+        assert_eq!(a.modified_time.get(), a_modified);
+        assert_eq!(b.created_time.get(), b_created);
+        assert_eq!(b.modified_time.get(), b_modified);
+    }
+
+    /// rename_duplicates preserves timestamps from original entries.
+    #[test]
+    fn rename_duplicates_preserves_timestamps() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("test.bale");
+
+        // Create archive with duplicate entries.
+        {
+            let mut writer = ArchiveWriter::create(&path).unwrap();
+            writer.add_entry("file.txt", b"version 1", 0o644).unwrap();
+            writer.add_entry("file.txt", b"version 2", 0o644).unwrap();
+            writer.sync().unwrap();
+        }
+
+        // Read timestamps before rename (iterate to get both entries).
+        let timestamps_before: Vec<(i64, i64)> = {
+            let reader = ArchiveReader::open(&path).unwrap();
+            reader
+                .iter_entries()
+                .map(|(row, _)| (row.created_time.get(), row.modified_time.get()))
+                .collect()
+        };
+        assert_eq!(timestamps_before.len(), 2);
+
+        rename_duplicates(&path).unwrap();
+
+        // After rename: file(1).txt has first entry's timestamps,
+        // file.txt has second entry's timestamps.
+        let reader = ArchiveReader::open(&path).unwrap();
+        let renamed = reader.find_entry("file(1).txt").unwrap();
+        let original = reader.find_entry("file.txt").unwrap();
+
+        assert_eq!(renamed.created_time.get(), timestamps_before[0].0);
+        assert_eq!(renamed.modified_time.get(), timestamps_before[0].1);
+        assert_eq!(original.created_time.get(), timestamps_before[1].0);
+        assert_eq!(original.modified_time.get(), timestamps_before[1].1);
+    }
+
+    proptest! {
+        #![proptest_config(proptest_config::config())]
+
+        /// Compact round-trip preserves all entry metadata.
+        #[test]
+        fn compact_round_trip_preserves_metadata(
+            entries in prop::collection::vec(
+                (
+                    "[a-z]{1,8}\\.[a-z]{1,3}",  // path
+                    prop::collection::vec(any::<u8>(), 0..64),  // data
+                    prop::sample::select(vec![0o100644u32, 0o100755, 0o100600]),  // mode
+                ),
+                1..8,
+            ),
+        ) {
+            let dir = TempDir::new().unwrap();
+            let path = dir.path().join("test.bale");
+
+            // Create archive with generated entries.
+            {
+                let mut writer = ArchiveWriter::create(&path).unwrap();
+                for (entry_path, data, mode) in &entries {
+                    writer.add_entry(entry_path, data, *mode).unwrap();
+                }
+                writer.sync().unwrap();
+            }
+
+            // Collect metadata before compaction (last occurrence of each path wins).
+            let metadata_before: HashMap<String, (Vec<u8>, u32, i64, i64)> = {
+                let reader = ArchiveReader::open(&path).unwrap();
+                let mut map = HashMap::new();
+                for (row, path_bytes) in reader.iter_entries() {
+                    let p = ArchivePath::from_null_padded_bytes(path_bytes)
+                        .to_str_checked()
+                        .unwrap()
+                        .to_owned();
+                    let data = reader.read_data(row).unwrap().to_vec();
+                    map.insert(p, (data, row.mode.get(), row.created_time.get(), row.modified_time.get()));
+                }
+                map
+            };
+
+            compact(&path).unwrap();
+
+            // Verify all metadata is preserved.
+            let reader = ArchiveReader::open(&path).unwrap();
+            for (p, (expected_data, expected_mode, expected_created, expected_modified)) in &metadata_before {
+                let row = reader.find_entry(p).unwrap();
+                let data = reader.read_data(row).unwrap();
+                prop_assert_eq!(data, expected_data.as_slice());
+                prop_assert_eq!(row.mode.get(), *expected_mode);
+                prop_assert_eq!(row.created_time.get(), *expected_created);
+                prop_assert_eq!(row.modified_time.get(), *expected_modified);
+            }
+        }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,10 +35,10 @@ mod proptest_config;
 
 #[cfg(feature = "reader")]
 pub use archive::ArchiveReader;
+#[cfg(feature = "writer")]
+pub use archive::{AddEntryOptions, ArchiveWrite, ArchiveWriter};
 #[cfg(any(feature = "reader", feature = "writer"))]
 pub use archive::{Archive, ArchiveRead, DirEntry, Entry, FileEntry, SymlinkEntry};
-#[cfg(feature = "writer")]
-pub use archive::{ArchiveWrite, ArchiveWriter};
 pub use archive_path::ArchivePath;
 #[cfg(feature = "compact")]
 pub use compact::{CompactStats, RenameStats, compact, rename_duplicates};

--- a/tests/proptest-regressions/compact.txt
+++ b/tests/proptest-regressions/compact.txt
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 5082ba28c2bd622539615529a7000df3b8424404f5b68fa67f760d33d0a9473e # shrinks to entries = [("bg.vlh", [132, 91, 148, 60, 113, 26, 30, 172, 141, 75, 192, 62, 214, 169, 36, 134, 208, 205, 187, 168, 24, 31, 229, 174, 86, 188, 72, 123, 128, 184, 102, 105, 212, 94, 146, 123, 191, 203, 20, 176, 187, 210, 160, 154, 168, 79, 157, 223, 180], 33188)]


### PR DESCRIPTION
## Summary
- Add public `AddEntryOptions` struct with optional `created_time` and `modified_time` fields
- Add `add_entry_with_options()` method on `ArchiveWriter` for flexible timestamp control
- Update `compact()` and `rename_duplicates()` to preserve original timestamps via the new API
- Refactor `add_entry_with_mtime` to delegate to `add_entry_with_options`

## Test plan
- [x] `compact_preserves_timestamps` — verifies created/modified times survive compaction
- [x] `rename_duplicates_preserves_timestamps` — verifies timestamps survive rename-dedup
- [x] `compact_round_trip_preserves_metadata` — proptest verifying all metadata (data, mode, timestamps) round-trips through compaction
- [x] All 227 existing tests pass
- [x] Clippy clean with `-D warnings`

Closes #203