### PR TITLE
Fix minor correctness issues (timestamps, bitflags, tombstones)

### DIFF
--- a/src/archive/reader.rs
+++ b/src/archive/reader.rs
@@ -309,6 +309,10 @@ impl ArchiveRead for Archive<MappedArchive> {
             let start = i * stride;
             let row = DirectoryRow::from_bytes(&table[start..start + stride], path_size).ok()?;
             let entry_id = row.entry_id();
+            // Skip tombstoned rows (entry_id == 0).
+            if entry_id == 0 {
+                return None;
+            }
             let entry_row = self.find_entry_row_by_id(entry_id)?;
             Some((entry_row, row.path_bytes_raw()))
         })

--- a/src/archive/writer.rs
+++ b/src/archive/writer.rs
@@ -20,10 +20,13 @@ use zerocopy::{FromBytes, IntoBytes};
 /// Converts a `SystemTime` to Unix epoch milliseconds.
 ///
 /// Returns a negative value for times before the Unix epoch.
+/// Saturates at `i64::MAX` / `i64::MIN` for extreme values.
 fn system_time_to_millis(time: SystemTime) -> i64 {
     match time.duration_since(SystemTime::UNIX_EPOCH) {
-        Ok(d) => d.as_millis() as i64,
-        Err(e) => -(e.duration().as_millis() as i64),
+        Ok(d) => i64::try_from(d.as_millis()).unwrap_or(i64::MAX),
+        Err(e) => i64::try_from(e.duration().as_millis())
+            .unwrap_or(i64::MAX)
+            .saturating_neg(),
     }
 }
 

--- a/src/format/trailer.rs
+++ b/src/format/trailer.rs
@@ -247,7 +247,9 @@ impl Trailer {
     /// or containing tombstones (e.g., insertion or deletion without full
     /// re-sort).
     pub fn clear_compacted(&mut self) {
-        self.flags = (self.flags() - TrailerFlags::COMPACTED).bits();
+        let mut flags = self.flags();
+        flags.remove(TrailerFlags::COMPACTED);
+        self.flags = flags.bits();
     }
 
     /// Returns `true` if the magic bytes match the expected value.


### PR DESCRIPTION
## Summary
- **`system_time_to_millis`**: Use `i64::try_from().unwrap_or()` with saturating negation instead of `as i64` which silently wraps on overflow
- **`clear_compacted`**: Use bitflags `remove()` method instead of arithmetic subtraction for clarity and safety
- **`iter_entries`**: Add explicit `entry_id == 0` tombstone skip instead of relying on `find_entry_row_by_id` returning `None`

## Test plan
- [x] All 392 existing tests pass
- [x] Clippy clean with `-D warnings`

Closes #210